### PR TITLE
feat: macOS support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -409,3 +409,113 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-macos:
+    name: Build macOS (.dmg)
+    runs-on: macos-latest
+    needs: lint
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: tauri -> tauri/target
+          shared-key: "rust-macos"
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Build Tauri app
+        run: npm run tauri:build -- --bundles dmg
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+
+      - name: Generate latest-macos-x86_64.json for updater
+        shell: bash
+        run: |
+          version="${{ github.ref_name }}"
+          if [[ "$version" != v* ]]; then version="0.0.0-nightly"; fi
+          version="${version#v}"
+
+          dmg=$(ls tauri/target/release/bundle/dmg/*.dmg 2>/dev/null | head -1)
+          if [ -z "$dmg" ]; then
+            echo "::error::No .dmg found in tauri/target/release/bundle/dmg/"
+            exit 1
+          fi
+
+          sig_file="${dmg}.sig"
+          if [ ! -f "$sig_file" ]; then
+            echo "::error::.sig file not found: $sig_file"
+            exit 1
+          fi
+
+          signature=$(cat "$sig_file")
+          pub_date=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+          filename=$(basename "$dmg")
+          download_url="https://github.com/xinnaider/orbit/releases/download/v${version}/${filename}"
+
+          jq -n \
+            --arg version  "$version" \
+            --arg notes    "See the full changelog at https://github.com/xinnaider/orbit/releases/tag/v${version}" \
+            --arg pub_date "$pub_date" \
+            --arg sig      "$signature" \
+            --arg url      "$download_url" \
+            '{version: $version, notes: $notes, pub_date: $pub_date, signature: $sig, url: $url}' \
+            > latest-macos-x86_64.json
+
+          echo "latest-macos-x86_64.json generated:"
+          cat latest-macos-x86_64.json
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: orbit-macos-${{ github.sha }}
+          path: |
+            tauri/target/release/bundle/dmg/*.dmg
+            tauri/target/release/bundle/dmg/*.dmg.sig
+            latest-macos-x86_64.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Resolve release metadata
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        id: meta
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=nightly-${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create/update Release with macOS assets
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          prerelease: ${{ steps.meta.outputs.prerelease }}
+          files: |
+            tauri/target/release/bundle/dmg/*.dmg
+            tauri/target/release/bundle/dmg/*.dmg.sig
+            latest-macos-x86_64.json
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## April 2026
 
+### 04/15 · New — macOS support
+Orbit is now available for macOS (Intel and Apple Silicon). Download the .dmg from the releases page, open it, and drag Orbit to your Applications folder.
+
 ### 04/09 · New — Sub-agents monitor tab
 
 When a session spawns sub-agents, they now appear in the "Sub-agents" tab on the right panel, grouped by Running and Completed. Click any agent to inspect its full conversation log in a modal. The list updates automatically as the session progresses, and a refresh button fetches the latest state on demand.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Guia de referência para o Claude Code trabalhar neste repositório.
 
 Orbit é um **dashboard desktop para gerenciar múltiplas sessões do Claude Code em paralelo**, construído com Tauri 2 (Rust + Svelte). Permite criar sessões, acompanhar output em tempo real, visualizar diffs de arquivos, tasks e tokens consumidos.
 
-- Plataformas: **Windows 10 1903+**, **Ubuntu 22.04+** (e outras distros Linux com webkit2gtk 4.1)
+- Plataformas: **Windows 10 1903+**, **Ubuntu 22.04+** (e outras distros Linux com webkit2gtk 4.1), **macOS** (Intel e Apple Silicon)
 - Identificador: `com.josefernando.orbit`
 - Repositório: `github.com/xinnaider/orbit`
 


### PR DESCRIPTION
Closes #21

## Summary

- Adds `build-macos` CI job to `.github/workflows/build.yml`
  - Runner: `macos-latest`
  - Rust targets: Intel (`x86_64-apple-darwin`) + Apple Silicon (`aarch64-apple-darwin`)
  - Generates `latest-macos-x86_64.json` for the auto-updater
  - Publishes `.dmg` to GitHub Releases

## No code changes required

The Rust + Svelte codebase was already cross-platform compatible. All platform-specific branches use `#[cfg(windows)]` / `#[cfg(not(windows))]` — macOS falls into the Unix path throughout. The Claude CLI binary search already included `/opt/homebrew/bin/claude`.

## Test plan

- [ ] Push triggers `build-macos` job on `macos-latest`
- [ ] `.dmg` artifact is uploaded successfully
- [ ] `latest-macos-x86_64.json` is generated and published to GitHub Releases
- [ ] App opens and creates a session correctly on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)