### PR TITLE
feat: read custom providers from opencode.jsonc

### DIFF
--- a/docs/specs/opencode-custom-providers.md
+++ b/docs/specs/opencode-custom-providers.md
@@ -1,0 +1,64 @@
+# Spec: OpenCode Custom Providers (opencode.jsonc)
+
+## Objective
+
+Read user-defined custom providers from `~/.config/opencode/opencode.jsonc` and merge them
+into the list of OpenCode sub-providers shown in Orbit's provider selection UI.
+
+Currently, Orbit reads only the provider cache from `~/.cache/opencode/models.json`. Providers
+defined inline by the user in `opencode.jsonc` (e.g. CrofAI, custom OpenAI-compatible endpoints)
+are ignored, leaving those models unavailable in Orbit.
+
+---
+
+## Expected Behavior
+
+1. On each call to `get_providers()`, after loading `models.json`, Orbit also reads
+   `~/.config/opencode/opencode.jsonc`.
+2. Each entry under the `"provider"` key becomes a `SubProvider` with:
+   - `id`: the object key (e.g. `"CrofAI"`)
+   - `name`: `provider.name` if present, otherwise the key
+   - `env`: empty vec — custom providers use inline `options.apiKey`, not env vars
+   - `configured`: `true` if `provider.options.apiKey` is a non-empty string
+   - `models`: derived from `provider.models` — same shape as `models.json` entries
+     (`id`, `name`, `limit.context`, `limit.output`)
+3. Providers whose `id` already exists in the `models.json` cache are **not duplicated** —
+   `models.json` takes precedence for any ID that appears in both sources.
+4. The merged list is sorted alphabetically by `name` before being returned.
+5. If `opencode.jsonc` does not exist, cannot be read, or cannot be parsed, the function
+   returns silently with no error — the existing `models.json` providers are unaffected.
+
+---
+
+## Edge Cases
+
+| Scenario | Expected result |
+|----------|----------------|
+| File does not exist | `None` — silent, no error logged |
+| File exists but is empty | `None` |
+| File is valid JSON (no comments) | Parsed correctly |
+| File has `// line` and `/* block */` comments | Comments stripped before JSON parse |
+| File has `\"` escape inside a JSON string value | Escape preserved correctly |
+| `"provider"` key absent | Returns empty vec — no sub-providers from this source |
+| Provider entry has no `"name"` field | Falls back to the key as name |
+| Provider entry has no `"options"` | `configured: false` |
+| `options.apiKey` is `""` (empty string) | `configured: false` |
+| `options.apiKey` is a non-empty string | `configured: true` |
+| Provider entry has no `"models"` | `models: []` |
+| Same provider ID in both `models.json` and `opencode.jsonc` | `models.json` entry wins; jsonc entry skipped |
+| Multiple custom providers defined | All are merged and sorted alphabetically |
+
+---
+
+## Acceptance Criteria
+
+- [ ] A new function `strip_jsonc_comments(s: &str) -> String` correctly removes `//` line
+      comments and `/* */` block comments while preserving string contents.
+- [ ] A new function `read_opencode_jsonc_providers() -> Option<Vec<SubProvider>>` reads and
+      parses `~/.config/opencode/opencode.jsonc`, returning `None` silently on any failure.
+- [ ] `get_providers()` merges custom providers after the `models.json` cache, deduplicating by
+      `id`, and returns a sorted combined list.
+- [ ] No `unwrap()` or `expect()` calls in the new code paths.
+- [ ] Passes `cargo clippy -- -D warnings` and `cargo fmt` without issues.
+- [ ] If the user has a CrofAI entry in `opencode.jsonc`, its models appear in the Orbit provider
+      selector under the OpenCode backend.

--- a/tauri/src/commands/providers.rs
+++ b/tauri/src/commands/providers.rs
@@ -51,7 +51,15 @@ pub fn get_providers(
             .unwrap_or(usize::MAX)
     });
 
-    let opencode_sub_providers = read_opencode_providers().unwrap_or_default();
+    let mut opencode_sub_providers = read_opencode_providers().unwrap_or_default();
+    // Merge custom providers from opencode.jsonc — skip IDs already present from cache
+    let jsonc_providers = read_opencode_jsonc_providers().unwrap_or_default();
+    for custom in jsonc_providers {
+        if !opencode_sub_providers.iter().any(|sp| sp.id == custom.id) {
+            opencode_sub_providers.push(custom);
+        }
+    }
+    opencode_sub_providers.sort_by(|a, b| a.name.cmp(&b.name));
 
     providers
         .iter()
@@ -376,6 +384,144 @@ fn read_opencode_providers() -> Option<Vec<SubProvider>> {
         .collect();
 
     result.sort_by(|a, b| a.name.cmp(&b.name));
+    Some(result)
+}
+
+/// Strip `//` line comments and `/* */` block comments from a JSONC string.
+///
+/// Tracks parser state to avoid stripping comment-like sequences inside JSON string literals.
+/// Newlines inside stripped line comments are preserved so line numbers stay accurate.
+fn strip_jsonc_comments(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let chars: Vec<char> = s.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+    let mut in_string = false;
+    let mut in_line_comment = false;
+    let mut in_block_comment = false;
+
+    while i < len {
+        let c = chars[i];
+        let next = if i + 1 < len {
+            Some(chars[i + 1])
+        } else {
+            None
+        };
+
+        if in_line_comment {
+            // Preserve the newline so line numbers stay intact, then exit comment mode
+            if c == '\n' {
+                in_line_comment = false;
+                out.push(c);
+            }
+            i += 1;
+            continue;
+        }
+
+        if in_block_comment {
+            if c == '*' && next == Some('/') {
+                in_block_comment = false;
+                i += 2;
+            } else {
+                // Preserve newlines inside block comments for the same reason
+                if c == '\n' {
+                    out.push(c);
+                }
+                i += 1;
+            }
+            continue;
+        }
+
+        if in_string {
+            out.push(c);
+            if c == '\\' && next.is_some() {
+                // Consume the escaped character so `\"` doesn't end the string
+                i += 1;
+                out.push(chars[i]);
+            } else if c == '"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+
+        // Outside string and comment — check for comment starts
+        if c == '/' && next == Some('/') {
+            in_line_comment = true;
+            i += 2;
+            continue;
+        }
+        if c == '/' && next == Some('*') {
+            in_block_comment = true;
+            i += 2;
+            continue;
+        }
+        if c == '"' {
+            in_string = true;
+        }
+        out.push(c);
+        i += 1;
+    }
+
+    out
+}
+
+/// Read user-defined providers from `~/.config/opencode/opencode.jsonc`.
+///
+/// Returns `None` silently if the file is absent, unreadable, or unparseable —
+/// callers merge the result with the models.json cache via `unwrap_or_default()`.
+fn read_opencode_jsonc_providers() -> Option<Vec<SubProvider>> {
+    let home = dirs::home_dir()?;
+    let path = home.join(".config").join("opencode").join("opencode.jsonc");
+    let raw = std::fs::read_to_string(&path).ok()?;
+    let stripped = strip_jsonc_comments(&raw);
+    let data: serde_json::Value = serde_json::from_str(&stripped).ok()?;
+    let providers_obj = data.get("provider").and_then(|v| v.as_object())?;
+
+    let result = providers_obj
+        .iter()
+        .map(|(id, provider)| {
+            let name = provider
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or(id)
+                .to_string();
+
+            // Custom providers store their API key inline in options.apiKey, not in env vars
+            let configured = provider
+                .pointer("/options/apiKey")
+                .and_then(|v| v.as_str())
+                .is_some_and(|key| !key.is_empty());
+
+            let models: Vec<ModelInfo> = provider
+                .get("models")
+                .and_then(|v| v.as_object())
+                .map(|m| {
+                    m.iter()
+                        .map(|(mid, mval)| ModelInfo {
+                            id: mid.clone(),
+                            name: mval
+                                .get("name")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or(mid)
+                                .to_string(),
+                            context: mval.pointer("/limit/context").and_then(|v| v.as_u64()),
+                            output: mval.pointer("/limit/output").and_then(|v| v.as_u64()),
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            SubProvider {
+                id: id.clone(),
+                name,
+                env: vec![],
+                configured,
+                models,
+            }
+        })
+        .collect();
+
     Some(result)
 }
 


### PR DESCRIPTION
## Summary

- Merges providers defined in `~/.config/opencode/opencode.jsonc` into the OpenCode sub-provider list, making user-defined models (e.g. CrofAI, custom OpenAI-compatible endpoints) available in Orbit's provider selector
- Adds `strip_jsonc_comments()` to handle JSONC format before parsing
- Deduplicates by ID — `models.json` cache takes precedence; custom entries only added if not already present
- Merged list is sorted alphabetically by name
- Silent fallback if file is absent or unparseable — existing flow is unaffected

Closes #25
Spec: `docs/specs/opencode-custom-providers.md`

## Test plan

- [ ] With a `~/.config/opencode/opencode.jsonc` containing a custom provider entry, verify it appears in the provider selector under the OpenCode backend
- [ ] With no `opencode.jsonc` file, verify provider list loads normally without errors
- [ ] With a malformed `opencode.jsonc`, verify the app still loads with only `models.json` providers
- [ ] Verify providers already in `models.json` are not duplicated even if also defined in `opencode.jsonc`
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)