### PR TITLE
feat: unify subagent support + copy full file content + bash command/output split

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "orbit": {
-      "command": "tauri/binaries/orbit-mcp-x86_64-pc-windows-msvc.exe"
+      "command": "C:\\Users\\fernandonepen\\Documents\\orbit\\tauri\\target\\debug\\orbit-mcp.exe"
     }
   }
 }

--- a/.opencode/plans/2026-04-16-chat-history-ctrlc-tab-dedup.md
+++ b/.opencode/plans/2026-04-16-chat-history-ctrlc-tab-dedup.md
@@ -1,0 +1,270 @@
+# Chat History, Ctrl+C Kill, and Tab Dedup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add message history navigation (Arrow Up/Down), Ctrl+C to kill the agent process, and prevent duplicate session tabs in the workspace.
+
+**Architecture:** Three independent features, each touching distinct areas. (1) InputBar gets a per-session message history ring buffer with Arrow Up/Down navigation. (2) InputBar captures Ctrl+C when focused and calls `stopSession`. (3) Workspace assignSession already deduplicates — verify current behavior works and ensure Sidebar click respects it.
+
+**Tech Stack:** Svelte 5, TypeScript, Tauri IPC, Rust (no changes needed)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `ui/components/InputBar.svelte` | Modify | Add history navigation, Ctrl+C handler |
+| `ui/lib/stores/history.ts` | Create | Per-session message history store (ring buffer, localStorage-backed) |
+| `ui/lib/mock/tauri-mock.ts` | Modify | No changes needed — `stop_session` mock already exists |
+| `ui/components/Sidebar.svelte` | Verify | Ensure `assignSession` dedup works (already implemented) |
+
+No Rust changes needed — `stopSession` IPC already exists and works for all providers.
+
+---
+
+### Task 1: Create message history store
+
+**Files:**
+- Create: `ui/lib/stores/history.ts`
+
+- [ ] **Step 1: Create the history store module**
+
+```typescript
+// ui/lib/stores/history.ts
+const MAX_HISTORY = 50;
+const STORAGE_KEY = 'orbit:message-history';
+
+interface SessionHistory {
+  messages: string[];
+  cursor: number;
+  savedText: string;
+}
+
+function loadAll(): Record<string, string[]> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function persistAll(all: Record<string, string[]>) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+  } catch {
+    // localStorage full
+  }
+}
+
+function createHistory() {
+  const all = loadAll();
+  const sessions: Record<string, SessionHistory> = {};
+
+  function get(sessionId: string): SessionHistory {
+    if (!sessions[sessionId]) {
+      sessions[sessionId] = {
+        messages: all[sessionId] ?? [],
+        cursor: -1,
+        savedText: '',
+      };
+    }
+    return sessions[sessionId];
+  }
+
+  function push(sessionId: string, message: string) {
+    const h = get(sessionId);
+    if (h.messages.length > 0 && h.messages[0] === message) return;
+    h.messages.unshift(message);
+    if (h.messages.length > MAX_HISTORY) h.messages.length = MAX_HISTORY;
+    h.cursor = -1;
+    h.savedText = '';
+    all[sessionId] = h.messages;
+    persistAll(all);
+  }
+
+  function up(sessionId: string, currentText: string): string | null {
+    const h = get(sessionId);
+    if (h.cursor === -1) {
+      h.savedText = currentText;
+    }
+    if (h.cursor < h.messages.length - 1) {
+      h.cursor++;
+      return h.messages[h.cursor];
+    }
+    return null;
+  }
+
+  function down(sessionId: string): string | null {
+    const h = get(sessionId);
+    if (h.cursor > 0) {
+      h.cursor--;
+      return h.messages[h.cursor];
+    }
+    if (h.cursor === 0) {
+      h.cursor = -1;
+      return h.savedText;
+    }
+    return null;
+  }
+
+  function resetCursor(sessionId: string) {
+    const h = get(sessionId);
+    h.cursor = -1;
+    h.savedText = '';
+  }
+
+  return { push, up, down, resetCursor };
+}
+
+export const messageHistory = createHistory();
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ui/lib/stores/history.ts
+git commit -m "feat: add per-session message history store with localStorage persistence"
+```
+
+---
+
+### Task 2: Wire history into InputBar with Arrow Up/Down
+
+**Files:**
+- Modify: `ui/components/InputBar.svelte:1-10` (imports), `:27-31` (state), `:366-372` (onKey handler), `:328-337` (send)
+
+- [ ] **Step 1: Add history import**
+
+In `InputBar.svelte`, add to the imports at top of `<script>`:
+
+```typescript
+import { messageHistory } from '../lib/stores/history';
+```
+
+- [ ] **Step 2: Add `stopSession` to the tauri import**
+
+Find the existing import from `'../lib/tauri'` in InputBar.svelte and add `stopSession`:
+
+```typescript
+import { sendSessionMessage, updateSessionModel, updateSessionEffort, stopSession } from '../lib/tauri';
+```
+
+- [ ] **Step 3: Push message to history after successful send**
+
+In the `send()` function, find the regular message path (after `await sendSessionMessage(sessionId, msg);` succeeds), add before `text = ''`:
+
+```typescript
+messageHistory.push(String(sessionId), msg);
+```
+
+The exact location: inside the `send()` function, the block where `text = ''` is set after a regular message send (not `/model`, `/effort`, or `/orchestrate` intercepts).
+
+- [ ] **Step 4: Replace the `onKey` function**
+
+Replace the existing `onKey` function (lines 366-372) with:
+
+```typescript
+function onKey(e: KeyboardEvent) {
+  if (picker?.handleKey(e)) return;
+
+  if (e.ctrlKey && e.key === 'c' && text === '') {
+    e.preventDefault();
+    stopSession(sessionId);
+    return;
+  }
+
+  if (e.key === 'ArrowUp' && text === '') {
+    e.preventDefault();
+    const prev = messageHistory.up(String(sessionId), text);
+    if (prev !== null) text = prev;
+    return;
+  }
+
+  if (e.key === 'ArrowDown' && text === '') {
+    e.preventDefault();
+    const next = messageHistory.down(String(sessionId));
+    if (next !== null) text = next;
+    return;
+  }
+
+  if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') {
+    messageHistory.resetCursor(String(sessionId));
+  }
+
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    send();
+  }
+}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/components/InputBar.svelte
+git commit -m "feat: Arrow Up/Down message history and Ctrl+C to kill agent in InputBar"
+```
+
+---
+
+### Task 3: Verify tab dedup works correctly
+
+**Files:**
+- Verify: `ui/lib/stores/workspace.ts:45-58` (assignSession)
+- Verify: `ui/components/Sidebar.svelte:250-254` (click handler)
+
+The current `assignSession` already deduplicates correctly:
+
+```typescript
+export function assignSession(paneId: string, sessionId: number): void {
+  workspace.update((ws) => {
+    for (const [pid, pane] of Object.entries(ws.panes)) {
+      if (pane.sessionId === sessionId) {
+        return { ...ws, focusedPaneId: pid }; // focus existing pane
+      }
+    }
+    ws.panes[paneId] = { sessionId };
+    ws.focusedPaneId = paneId;
+    return ws;
+  });
+}
+```
+
+- [ ] **Step 1: Manual verification** — Click a session already open in another pane. Confirm it focuses the existing pane instead of duplicating.
+
+- [ ] **Step 2: Commit** (only if a bug was found and fixed)
+
+---
+
+### Task 4: Run lint and type checks
+
+- [ ] **Step 1: Run ESLint + svelte-check**
+
+```bash
+npx eslint ui/components/InputBar.svelte ui/lib/stores/history.ts --max-warnings 0
+npx svelte-check --fail-on-warnings
+```
+
+Expected: 0 errors, 0 warnings
+
+- [ ] **Step 2: Run cargo clippy + cargo test**
+
+```bash
+cd tauri && cargo clippy -- -D warnings && cargo test
+```
+
+Expected: 0 errors, all 126+ tests pass
+
+- [ ] **Step 3: Commit if any fixes were needed**
+
+---
+
+## Scope Notes
+
+- **Arrow Up/Down only works when input is empty** — avoids breaking text cursor movement in the textarea. Matches shell behavior.
+- **Ctrl+C only kills when InputBar is focused AND text is empty** — prevents accidental kills when typing. Matches user's preference.
+- **Tab dedup** — already working via `assignSession`. No code changes needed, just verification.
+- **SSH sessions** — Ctrl+C uses `stopSession` which calls `kill_pid()` on the local SSH process, terminating the remote agent.
+- **All providers** — same `stopSession` IPC path. PID-based kill works for Claude, Codex, OpenCode, ACP, and SSH.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ## April 2026
 
+### 04/22 · New — Subagent support for all providers
+The agents tab is now visible for every CLI backend, not just Claude Code.
+Subagent spawns are detected dynamically based on each provider's tool names
+(e.g. "Agent" and "Task" for Claude, "Task" for Codex and ACP), eliminating
+a hardcoded check that previously blocked Codex and OpenCode users from seeing
+sub-agents.
+
+### 04/22 · New — Sidebar no longer shows virtual subagent sessions
+The sidebar now displays only real sessions without indented virtual children
+that appeared under their parent. Subagent status is still available in the
+agents tab on the right panel.
+
 ### 04/16 · New — Message history navigation
 Press Arrow Up when the cursor is at the start of the input to recall previous messages
 sent in that session, and Arrow Down when the cursor is at the end to go forward.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## April 2026
 
+### 04/22 · New — Copy content from any tool call
+Every tool call in the session feed now has a copy button. Clicking it copies the relevant content to the clipboard instantly. For file edits, it copies the new code; for file writes, it copies the entire file content; for bash commands, it copies the command itself; and for read/grep results, it copies the output. The button appears both inline in the feed and inside the fullscreen modal.
+
 ### 04/22 · Fix — Display model alias instead of raw ID
 When Claude Opus 4.7 is selected, the sidebar and top bar now display "Opus 4.7" instead of the internal model ID. The display name was missing from the frontend lookup table, causing the raw name to leak through.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Subagent spawns are detected dynamically based on each provider's tool names
 a hardcoded check that previously blocked Codex and OpenCode users from seeing
 sub-agents.
 
-### 04/22 · New — Sidebar no longer shows virtual subagent sessions
+### 04/22 · New — Claude Opus 4.7 with extended effort levels
+Claude Opus 4.7 is now available in the model selector, alongside its 1-million-token context variant. When Opus 4.7 is selected, two additional effort levels appear in the /effort command: `xhigh` and `auto`. Other models continue to offer the classic `low`, `medium`, `high`, and `max` levels.
 The sidebar now displays only real sessions without indented virtual children
 that appeared under their parent. Subagent status is still available in the
 agents tab on the right panel.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## April 2026
 
+### 04/22 · Fix — Display model alias instead of raw ID
+When Claude Opus 4.7 is selected, the sidebar and top bar now display "Opus 4.7" instead of the internal model ID. The display name was missing from the frontend lookup table, causing the raw name to leak through.
+
+### 04/22 · Fix — Slash command picker arrow-key navigation
+Scrolling through the option list in `/model` or `/effort` with the keyboard now works properly. Arrow Up and Arrow Down were being overridden by a reactive statement that reset the index on every redraw, rather than only when the filtered list changed.
+
 ### 04/22 · New — Subagent support for all providers
 The agents tab is now visible for every CLI backend, not just Claude Code.
 Subagent spawns are detected dynamically based on each provider's tool names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## April 2026
 
+### 04/22 · Improvement — Copy always copies the full file content
+The copy button on file tool calls (Read, Edit, Write) now reads the actual file from disk and copies its current complete content to the clipboard. Previously, copying an Edit only grabbed the small replacement snippet, leaving most of the file behind. A fallback keeps copying inline data when the file cannot be accessed (for example, in remote SSH sessions).
+
 ### 04/22 · New — Copy content from any tool call
 Every tool call in the session feed now has a copy button. Clicking it copies the relevant content to the clipboard instantly. For file edits, it copies the new code; for file writes, it copies the entire file content; for bash commands, it copies the command itself; and for read/grep results, it copies the output. The button appears both inline in the feed and inside the fullscreen modal.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ The sidebar now displays only real sessions without indented virtual children
 that appeared under their parent. Subagent status is still available in the
 agents tab on the right panel.
 
+### 04/22 · New — Tasks tab gated by provider capability
+The tasks tab is now shown only for providers that can emit todo lists.
+Each provider declares its task support, tool names, and JSON format —
+Claude Code uses `TodoWrite` tool calls, OpenCode uses `todowrite` events,
+and Codex uses `todo_list` items. ACP providers do not show the tab.
+When a running session receives a task list update, the tasks tab refreshes
+immediately via a realtime event instead of waiting for the 3-second poll.
+
 ### 04/16 · New — Message history navigation
 Press Arrow Up when the cursor is at the start of the input to recall previous messages
 sent in that session, and Arrow Down when the cursor is at the end to go forward.

--- a/tauri/Cargo.lock
+++ b/tauri/Cargo.lock
@@ -2714,7 +2714,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbit"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "aes-gcm",
  "agent-client-protocol-schema",

--- a/tauri/src/commands/files.rs
+++ b/tauri/src/commands/files.rs
@@ -51,6 +51,11 @@ pub fn get_subagent_journal(
 }
 
 #[tauri::command]
+pub fn read_file_content(path: String) -> Result<String, String> {
+    std::fs::read_to_string(&path).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 pub fn list_project_files(cwd: String) -> Vec<String> {
     use ignore::WalkBuilder;
 

--- a/tauri/src/commands/mod.rs
+++ b/tauri/src/commands/mod.rs
@@ -9,7 +9,7 @@ pub mod tasks;
 
 pub use agents::get_subagents;
 pub use diff::{get_diff, get_file_versions};
-pub use files::{get_subagent_journal, list_project_files};
+pub use files::{get_subagent_journal, list_project_files, read_file_content};
 pub use plugins::get_slash_commands;
 pub use providers::{check_env_var, get_providers};
 pub use stats::{get_changelog, get_claude_usage_stats, get_rate_limits};

--- a/tauri/src/commands/providers.rs
+++ b/tauri/src/commands/providers.rs
@@ -65,7 +65,7 @@ pub fn get_providers(
                 install_hint: p.install_hint().to_string(),
                 supports_effort: p.supports_effort(),
                 supports_ssh: p.supports_ssh(),
-                supports_subagents: p.id() == "claude-code", // only Claude has subagents
+                supports_subagents: p.supports_subagents(),
                 has_sub_providers: has_subs,
                 models: get_provider_models(p.id()),
                 sub_providers: if has_subs {
@@ -88,6 +88,12 @@ fn get_provider_models(provider_id: &str) -> Vec<ModelInfo> {
                 name: "auto".into(),
                 context: None,
                 output: None,
+            },
+            ModelInfo {
+                id: "claude-opus-4-7".into(),
+                name: "opus-4.7".into(),
+                context: Some(1_000_000),
+                output: Some(128_000),
             },
             ModelInfo {
                 id: "claude-sonnet-4-6".into(),

--- a/tauri/src/commands/providers.rs
+++ b/tauri/src/commands/providers.rs
@@ -33,6 +33,8 @@ pub struct CliBackend {
     pub models: Vec<ModelInfo>,
     /// Sub-providers (for opencode only)
     pub sub_providers: Vec<SubProvider>,
+    /// Effort levels keyed by model glob; empty when effort not supported.
+    pub effort_levels: std::collections::HashMap<String, Vec<String>>,
 }
 
 /// Return all CLI backends with their capabilities and models.
@@ -57,6 +59,17 @@ pub fn get_providers(
         .iter()
         .map(|p| {
             let has_subs = p.id() == "opencode" && !opencode_sub_providers.is_empty();
+            let models = get_provider_models(p.id());
+            let mut effort_levels = std::collections::HashMap::new();
+            for model in &models {
+                let levels = p.effort_levels(&model.id);
+                if !levels.is_empty() {
+                    effort_levels.insert(
+                        model.id.clone(),
+                        levels.iter().map(|s| s.to_string()).collect(),
+                    );
+                }
+            }
             CliBackend {
                 id: p.id().to_string(),
                 name: p.display_name().to_string(),
@@ -67,7 +80,8 @@ pub fn get_providers(
                 supports_ssh: p.supports_ssh(),
                 supports_subagents: p.supports_subagents(),
                 has_sub_providers: has_subs,
-                models: get_provider_models(p.id()),
+                effort_levels,
+                models,
                 sub_providers: if has_subs {
                     opencode_sub_providers.clone()
                 } else {

--- a/tauri/src/commands/providers.rs
+++ b/tauri/src/commands/providers.rs
@@ -28,6 +28,7 @@ pub struct CliBackend {
     pub supports_effort: bool,
     pub supports_ssh: bool,
     pub supports_subagents: bool,
+    pub supports_tasks: bool,
     pub has_sub_providers: bool,
     /// Direct models (for claude-code and codex)
     pub models: Vec<ModelInfo>,
@@ -35,6 +36,10 @@ pub struct CliBackend {
     pub sub_providers: Vec<SubProvider>,
     /// Effort levels keyed by model glob; empty when effort not supported.
     pub effort_levels: std::collections::HashMap<String, Vec<String>>,
+    /// Tool names that trigger task detection for this provider (e.g. ["TodoWrite"]).
+    pub task_tool_names: Vec<String>,
+    /// Format this provider uses to emit tasks.
+    pub task_format: String,
 }
 
 /// Return all CLI backends with their capabilities and models.
@@ -79,6 +84,7 @@ pub fn get_providers(
                 supports_effort: p.supports_effort(),
                 supports_ssh: p.supports_ssh(),
                 supports_subagents: p.supports_subagents(),
+                supports_tasks: p.supports_tasks(),
                 has_sub_providers: has_subs,
                 effort_levels,
                 models,
@@ -86,6 +92,12 @@ pub fn get_providers(
                     opencode_sub_providers.clone()
                 } else {
                     vec![]
+                },
+                task_tool_names: p.task_tool_names().iter().map(|s| s.to_string()).collect(),
+                task_format: match p.task_format() {
+                    crate::models::TaskFormat::ClaudeToolUse => "claude_tool_use".to_string(),
+                    crate::models::TaskFormat::OpenCodeToolUse => "opencode_tool_use".to_string(),
+                    crate::models::TaskFormat::CodexItemList => "codex_item_list".to_string(),
                 },
             }
         })

--- a/tauri/src/ipc/session.rs
+++ b/tauri/src/ipc/session.rs
@@ -137,7 +137,7 @@ pub fn send_session_message(
         let arg = trimmed.get(8..).unwrap_or("").trim();
         if arg.is_empty() {
             return Err(IpcError::Other(
-                "Usage: /effort <level> (low, medium, high, max)".to_string(),
+                "Usage: /effort <level>".to_string(),
             ));
         }
         state.write().update_session_effort(session_id, arg)?;

--- a/tauri/src/ipc/session.rs
+++ b/tauri/src/ipc/session.rs
@@ -136,9 +136,7 @@ pub fn send_session_message(
         }
         let arg = trimmed.get(8..).unwrap_or("").trim();
         if arg.is_empty() {
-            return Err(IpcError::Other(
-                "Usage: /effort <level>".to_string(),
-            ));
+            return Err(IpcError::Other("Usage: /effort <level>".to_string()));
         }
         state.write().update_session_effort(session_id, arg)?;
         return Ok(());

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -104,6 +104,7 @@ pub fn run() {
             commands::files::get_subagent_journal,
             commands::plugins::get_slash_commands,
             commands::files::list_project_files,
+            commands::files::read_file_content,
             commands::tasks::get_tasks,
             commands::stats::get_claude_usage_stats,
             commands::stats::get_rate_limits,

--- a/tauri/src/models.rs
+++ b/tauri/src/models.rs
@@ -195,6 +195,8 @@ pub struct TaskItem {
 /// Map raw model IDs to human-friendly display names.
 pub fn model_display_name(model_id: &str) -> &str {
     match model_id {
+        "claude-opus-4-7" => "Opus 4.7",
+        "claude-opus-4-7[1m]" => "Opus 4.7 (1M)",
         "claude-opus-4-6" => "Opus 4.6",
         "claude-opus-4-6[1m]" => "Opus 4.6 (1M)",
         "claude-sonnet-4-6" => "Sonnet 4.6",
@@ -206,7 +208,7 @@ pub fn model_display_name(model_id: &str) -> &str {
 /// Context window size for a given model ID.
 pub fn context_window(model_id: &str) -> u64 {
     match model_id {
-        "claude-opus-4-6[1m]" => 1_000_000,
+        "claude-opus-4-7[1m]" | "claude-opus-4-6[1m]" => 1_000_000,
         _ => 200_000,
     }
 }

--- a/tauri/src/models.rs
+++ b/tauri/src/models.rs
@@ -180,6 +180,18 @@ pub struct SlashCommand {
     pub category: String,
 }
 
+/// The JSON structure format a provider uses to emit task lists in its stdout.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskFormat {
+    /// Claude Code: assistant→content[].tool_use(name=TodoWrite)
+    ClaudeToolUse,
+    /// OpenCode: tool_use→part.tool=todowrite
+    OpenCodeToolUse,
+    /// Codex: item.completed→item.type=todo_list
+    CodexItemList,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TaskItem {

--- a/tauri/src/providers/acp.rs
+++ b/tauri/src/providers/acp.rs
@@ -131,6 +131,19 @@ impl Provider for AcpProvider {
         &["Task"]
     }
 
+    fn supports_tasks(&self) -> bool {
+        false
+    }
+
+    fn task_tool_names(&self) -> &[&str] {
+        &[]
+    }
+
+    fn task_format(&self) -> crate::models::TaskFormat {
+        // Fallback — never used because supports_tasks is false
+        crate::models::TaskFormat::ClaudeToolUse
+    }
+
     fn line_processor(&self) -> fn(&mut JournalState, &str) {
         process_acp_line
     }

--- a/tauri/src/providers/acp.rs
+++ b/tauri/src/providers/acp.rs
@@ -115,6 +115,10 @@ impl Provider for AcpProvider {
         false
     }
 
+    fn effort_levels(&self, _model: &str) -> &[&str] {
+        &[]
+    }
+
     fn supports_ssh(&self) -> bool {
         false
     }

--- a/tauri/src/providers/acp.rs
+++ b/tauri/src/providers/acp.rs
@@ -119,6 +119,14 @@ impl Provider for AcpProvider {
         false
     }
 
+    fn supports_subagents(&self) -> bool {
+        true
+    }
+
+    fn subagent_tool_names(&self) -> &[&str] {
+        &["Task"]
+    }
+
     fn line_processor(&self) -> fn(&mut JournalState, &str) {
         process_acp_line
     }

--- a/tauri/src/providers/claude.rs
+++ b/tauri/src/providers/claude.rs
@@ -118,6 +118,15 @@ impl Provider for ClaudeProvider {
     fn subagent_tool_names(&self) -> &[&str] {
         &["Agent", "Task"]
     }
+    fn supports_tasks(&self) -> bool {
+        true
+    }
+    fn task_tool_names(&self) -> &[&str] {
+        &["TodoWrite"]
+    }
+    fn task_format(&self) -> crate::models::TaskFormat {
+        crate::models::TaskFormat::ClaudeToolUse
+    }
     fn line_processor(&self) -> fn(&mut JournalState, &str) {
         crate::journal::process_line
     }

--- a/tauri/src/providers/claude.rs
+++ b/tauri/src/providers/claude.rs
@@ -105,6 +105,12 @@ impl Provider for ClaudeProvider {
     fn supports_ssh(&self) -> bool {
         true
     }
+    fn supports_subagents(&self) -> bool {
+        true
+    }
+    fn subagent_tool_names(&self) -> &[&str] {
+        &["Agent", "Task"]
+    }
     fn line_processor(&self) -> fn(&mut JournalState, &str) {
         crate::journal::process_line
     }

--- a/tauri/src/providers/claude.rs
+++ b/tauri/src/providers/claude.rs
@@ -102,6 +102,13 @@ impl Provider for ClaudeProvider {
     fn supports_effort(&self) -> bool {
         true
     }
+    fn effort_levels(&self, model: &str) -> &[&str] {
+        if model.contains("opus-4-7") {
+            &["low", "medium", "high", "xhigh", "max", "auto"]
+        } else {
+            &["low", "medium", "high", "max"]
+        }
+    }
     fn supports_ssh(&self) -> bool {
         true
     }

--- a/tauri/src/providers/codex.rs
+++ b/tauri/src/providers/codex.rs
@@ -92,6 +92,9 @@ impl Provider for CodexProvider {
     fn supports_effort(&self) -> bool {
         false
     }
+    fn effort_levels(&self, _model: &str) -> &[&str] {
+        &[]
+    }
     fn supports_ssh(&self) -> bool {
         true
     }

--- a/tauri/src/providers/codex.rs
+++ b/tauri/src/providers/codex.rs
@@ -95,6 +95,12 @@ impl Provider for CodexProvider {
     fn supports_ssh(&self) -> bool {
         true
     }
+    fn supports_subagents(&self) -> bool {
+        true
+    }
+    fn subagent_tool_names(&self) -> &[&str] {
+        &["Task"]
+    }
     fn line_processor(&self) -> fn(&mut JournalState, &str) {
         crate::journal::process_line_codex
     }

--- a/tauri/src/providers/codex.rs
+++ b/tauri/src/providers/codex.rs
@@ -104,6 +104,15 @@ impl Provider for CodexProvider {
     fn subagent_tool_names(&self) -> &[&str] {
         &["Task"]
     }
+    fn supports_tasks(&self) -> bool {
+        true
+    }
+    fn task_tool_names(&self) -> &[&str] {
+        &["todo_list"]
+    }
+    fn task_format(&self) -> crate::models::TaskFormat {
+        crate::models::TaskFormat::CodexItemList
+    }
     fn line_processor(&self) -> fn(&mut JournalState, &str) {
         crate::journal::process_line_codex
     }

--- a/tauri/src/providers/mod.rs
+++ b/tauri/src/providers/mod.rs
@@ -52,6 +52,10 @@ pub trait Provider: Send + Sync {
     /// Whether this provider supports the `effort` parameter.
     fn supports_effort(&self) -> bool;
 
+    /// Effort levels supported for a specific model, or empty slice if effort is not supported.
+    /// For Claude Code, Opus 4.7 supports an extended list (low, medium, high, xhigh, max, auto).
+    fn effort_levels(&self, model: &str) -> &[&str];
+
     /// Whether this provider supports SSH remote sessions.
     fn supports_ssh(&self) -> bool;
 
@@ -179,6 +183,13 @@ mod tests {
 
         fn supports_effort(&self) -> bool {
             self.mock_effort
+        }
+        fn effort_levels(&self, _model: &str) -> &[&str] {
+            if self.mock_effort {
+                &["low", "medium", "high", "max"]
+            } else {
+                &[]
+            }
         }
         fn supports_ssh(&self) -> bool {
             false

--- a/tauri/src/providers/mod.rs
+++ b/tauri/src/providers/mod.rs
@@ -55,6 +55,14 @@ pub trait Provider: Send + Sync {
     /// Whether this provider supports SSH remote sessions.
     fn supports_ssh(&self) -> bool;
 
+    /// Whether this CLI can spawn sub-agents (shown in the agents tab).
+    fn supports_subagents(&self) -> bool;
+
+    /// Tool names that represent a sub-agent spawn.
+    /// When the journal sees a `ToolCall` with one of these names,
+    /// a `session:subagent-created` event is emitted.
+    fn subagent_tool_names(&self) -> &[&str];
+
     /// Return a fn pointer for parsing JSONL lines in a Send thread.
     /// Needed because `&dyn Provider` is not Send across thread boundaries.
     fn line_processor(&self) -> fn(&mut crate::journal::JournalState, &str);
@@ -174,6 +182,12 @@ mod tests {
         }
         fn supports_ssh(&self) -> bool {
             false
+        }
+        fn supports_subagents(&self) -> bool {
+            false
+        }
+        fn subagent_tool_names(&self) -> &[&str] {
+            &[]
         }
         fn line_processor(&self) -> fn(&mut crate::journal::JournalState, &str) {
             |_, _| {}

--- a/tauri/src/providers/mod.rs
+++ b/tauri/src/providers/mod.rs
@@ -67,6 +67,17 @@ pub trait Provider: Send + Sync {
     /// a `session:subagent-created` event is emitted.
     fn subagent_tool_names(&self) -> &[&str];
 
+    /// Whether this provider can emit task lists (shown in the tasks tab).
+    fn supports_tasks(&self) -> bool;
+
+    /// Tool/structure names that represent a task list emission for this provider.
+    /// Used by the realtime parser to detect task updates in the output stream.
+    fn task_tool_names(&self) -> &[&str];
+
+    /// The JSON structure format this provider uses for task lists.
+    /// Used by get_tasks to select the correct parser.
+    fn task_format(&self) -> crate::models::TaskFormat;
+
     /// Return a fn pointer for parsing JSONL lines in a Send thread.
     /// Needed because `&dyn Provider` is not Send across thread boundaries.
     fn line_processor(&self) -> fn(&mut crate::journal::JournalState, &str);
@@ -199,6 +210,15 @@ mod tests {
         }
         fn subagent_tool_names(&self) -> &[&str] {
             &[]
+        }
+        fn supports_tasks(&self) -> bool {
+            false
+        }
+        fn task_tool_names(&self) -> &[&str] {
+            &[]
+        }
+        fn task_format(&self) -> crate::models::TaskFormat {
+            crate::models::TaskFormat::ClaudeToolUse
         }
         fn line_processor(&self) -> fn(&mut crate::journal::JournalState, &str) {
             |_, _| {}

--- a/tauri/src/providers/opencode.rs
+++ b/tauri/src/providers/opencode.rs
@@ -110,6 +110,15 @@ impl Provider for OpenCodeProvider {
     fn subagent_tool_names(&self) -> &[&str] {
         &["Task"]
     }
+    fn supports_tasks(&self) -> bool {
+        true
+    }
+    fn task_tool_names(&self) -> &[&str] {
+        &["todowrite"]
+    }
+    fn task_format(&self) -> crate::models::TaskFormat {
+        crate::models::TaskFormat::OpenCodeToolUse
+    }
     fn line_processor(&self) -> fn(&mut JournalState, &str) {
         crate::journal::process_line_opencode
     }

--- a/tauri/src/providers/opencode.rs
+++ b/tauri/src/providers/opencode.rs
@@ -98,6 +98,9 @@ impl Provider for OpenCodeProvider {
     fn supports_effort(&self) -> bool {
         false
     }
+    fn effort_levels(&self, _model: &str) -> &[&str] {
+        &[]
+    }
     fn supports_ssh(&self) -> bool {
         false // SSH not yet supported for OpenCode
     }

--- a/tauri/src/providers/opencode.rs
+++ b/tauri/src/providers/opencode.rs
@@ -101,6 +101,12 @@ impl Provider for OpenCodeProvider {
     fn supports_ssh(&self) -> bool {
         false // SSH not yet supported for OpenCode
     }
+    fn supports_subagents(&self) -> bool {
+        true
+    }
+    fn subagent_tool_names(&self) -> &[&str] {
+        &["Task"]
+    }
     fn line_processor(&self) -> fn(&mut JournalState, &str) {
         crate::journal::process_line_opencode
     }

--- a/tauri/src/services/session_manager.rs
+++ b/tauri/src/services/session_manager.rs
@@ -493,6 +493,11 @@ impl SessionManager {
         // 10. Get line processor fn pointer from the provider trait.
         // Uses fn pointer (not trait object) because threads require Send.
         let line_processor = provider.line_processor();
+        let subagent_tools: Vec<String> = provider
+            .subagent_tool_names()
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
 
         // 11. Reader loop
         Self::reader_loop(
@@ -503,6 +508,7 @@ impl SessionManager {
             db,
             handle.child,
             line_processor,
+            subagent_tools,
         );
     }
 
@@ -560,6 +566,7 @@ impl SessionManager {
     }
 
     /// Read JSON lines from Claude's stdout, parse, emit events.
+    #[allow(clippy::too_many_arguments)]
     fn reader_loop(
         manager: Arc<RwLock<SessionManager>>,
         app: AppHandle,
@@ -568,6 +575,7 @@ impl SessionManager {
         db: Arc<DatabaseService>,
         mut child: std::process::Child,
         line_processor: fn(&mut JournalState, &str),
+        subagent_tools: Vec<String>,
     ) {
         use std::io::BufRead;
         let mut reader = std::io::BufReader::new(reader);
@@ -735,10 +743,10 @@ impl SessionManager {
                         let mut e = entry.clone();
                         e.session_id = session_id.to_string();
 
-                        // Detect sub-agent spawns (Agent/Task tool calls)
+                        // Detect sub-agent spawns
                         if e.entry_type == crate::models::JournalEntryType::ToolCall {
                             if let Some(ref tool) = e.tool {
-                                if tool == "Agent" || tool == "Task" {
+                                if subagent_tools.contains(tool) {
                                     let desc = e
                                         .tool_input
                                         .as_ref()

--- a/tauri/src/services/session_manager.rs
+++ b/tauri/src/services/session_manager.rs
@@ -498,6 +498,11 @@ impl SessionManager {
             .iter()
             .map(|s| s.to_string())
             .collect();
+        let task_tools: Vec<String> = provider
+            .task_tool_names()
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
 
         // 11. Reader loop
         Self::reader_loop(
@@ -509,6 +514,7 @@ impl SessionManager {
             handle.child,
             line_processor,
             subagent_tools,
+            task_tools,
         );
     }
 
@@ -576,6 +582,7 @@ impl SessionManager {
         mut child: std::process::Child,
         line_processor: fn(&mut JournalState, &str),
         subagent_tools: Vec<String>,
+        task_tools: Vec<String>,
     ) {
         use std::io::BufRead;
         let mut reader = std::io::BufReader::new(reader);
@@ -760,6 +767,20 @@ impl SessionManager {
                                             "parentSessionId": session_id,
                                             "description": desc,
                                             "tool": tool,
+                                        }),
+                                    );
+                                }
+                            }
+                        }
+
+                        // Detect task list updates
+                        if e.entry_type == crate::models::JournalEntryType::ToolCall {
+                            if let Some(ref tool) = e.tool {
+                                if task_tools.contains(tool) {
+                                    let _ = app.emit(
+                                        "session:task-update",
+                                        serde_json::json!({
+                                            "sessionId": session_id,
                                         }),
                                     );
                                 }

--- a/test-file.md
+++ b/test-file.md
@@ -1,0 +1,49 @@
+# Arquivo de Teste - Orbit
+
+## Informações Aleatórias
+
+### Dados Curiosos
+
+- **Planeta favorito**: Júpiter (o maior do sistema solar!)
+- **Cor favorita**: #FF6B6B (Coral Red)
+- **Comida favorita**: Pizza de pepperoni 🍕
+- **Linguagem de programação**: TypeScript ⚡
+- **Framework favorito**: Svelte 5
+
+### Lista de Tarefas
+
+1. [x] Implementar botão Copy All
+2. [x] Ler conteúdo direto do arquivo
+3. [ ] Testar com arquivos grandes
+4. [ ] Adicionar feedback visual de loading
+
+### Código de Exemplo
+
+```rust
+fn main() {
+    println!("Hello, Orbit!");
+    let message = "Testing copy functionality";
+    println!("{}", message);
+}
+```
+
+```typescript
+async function copyFileContent(path: string) {
+    const content = await readFile(path);
+    await navigator.clipboard.writeText(content);
+    console.log("Copied!");
+}
+```
+
+### Notas Adicionais
+
+> "A simplicidade é o último grau de sofisticação."
+> — Leonardo da Vinci
+
+**Data de criação**: 17 de Abril de 2026  
+**Versão**: 1.0.0  
+**Status**: Em teste
+
+---
+
+*Este arquivo foi gerado automaticamente para testes do Orbit Dashboard.*

--- a/ui/App.svelte
+++ b/ui/App.svelte
@@ -12,6 +12,7 @@
   import { get } from 'svelte/store';
   import { assignSession, restoreWorkspace, workspace } from './lib/stores/workspace';
   import { journal } from './lib/stores/journal';
+  import { taskUpdateTrigger } from './lib/stores/tasks';
   import { addToast } from './lib/stores/toasts';
   import {
     listSessions,
@@ -24,6 +25,7 @@
     onSessionRunning,
     onSessionError,
     onSessionRateLimit,
+    onSessionTaskUpdate,
     getAppVersion,
     getChangelog,
   } from './lib/tauri';
@@ -168,8 +170,12 @@
       // Rate limit info is shown inline in the chat feed as a System entry
     });
 
+    const u8 = onSessionTaskUpdate((id) => {
+      taskUpdateTrigger.set(id);
+    });
+
     // Resolve all unlisten functions and store for cleanup
-    Promise.all([u1, u2, u3, u4, u5, u6, u7]).then((fns) => {
+    Promise.all([u1, u2, u3, u4, u5, u6, u7, u8]).then((fns) => {
       unlisteners = fns;
     });
 

--- a/ui/App.svelte
+++ b/ui/App.svelte
@@ -168,47 +168,8 @@
       // Rate limit info is shown inline in the chat feed as a System entry
     });
 
-    const u8 = listen<{
-      parentSessionId: number;
-      description: string;
-      tool: string;
-    }>('session:subagent-created', (e) => {
-      const { parentSessionId, description } = e.payload;
-      // Find parent session to inherit provider/cwd
-      const parent = $sessions.find((s) => s.id === parentSessionId);
-      if (!parent) return;
-      // Add a virtual child session to the store
-      const childId = -Date.now(); // negative ID = virtual (not in DB)
-      const child: Session = {
-        id: childId,
-        projectId: parent.projectId,
-        name: description,
-        status: 'running',
-        permissionMode: parent.permissionMode,
-        model: parent.model,
-        provider: parent.provider,
-        pid: null,
-        cwd: parent.cwd,
-        projectName: parent.projectName,
-        gitBranch: parent.gitBranch,
-        worktreePath: null,
-        branchName: null,
-        tokens: null,
-        contextPercent: null,
-        pendingApproval: null,
-        miniLog: null,
-        sshHost: null,
-        sshUser: null,
-        parentSessionId,
-        depth: (parent.depth ?? 0) + 1,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      };
-      sessions.update((l) => [child, ...l]);
-    });
-
     // Resolve all unlisten functions and store for cleanup
-    Promise.all([u1, u2, u3, u4, u5, u6, u7, u8]).then((fns) => {
+    Promise.all([u1, u2, u3, u4, u5, u6, u7]).then((fns) => {
       unlisteners = fns;
     });
 

--- a/ui/components/CentralPanel.svelte
+++ b/ui/components/CentralPanel.svelte
@@ -210,6 +210,7 @@
           {entries}
           status={session.status}
           provider={session.provider}
+          cwd={session.cwd}
           on:bottomchange={onFeedBottomChange}
         />
       {/key}

--- a/ui/components/Feed.svelte
+++ b/ui/components/Feed.svelte
@@ -8,6 +8,7 @@
   export let entries: JournalEntry[] = [];
   export let status: string = '';
   export let provider: string = 'claude-code';
+  export let cwd: string | null = null;
 
   $: agentLabel = (() => {
     const direct = $backends.find((b) => b.id === provider);
@@ -264,7 +265,7 @@
       </div>
     {:else if e.entryType === 'toolCall'}
       <div class="row tool">
-        <ToolCallEntry entry={e} resultEntry={r} streamingEntries={s} />
+        <ToolCallEntry entry={e} resultEntry={r} streamingEntries={s} {cwd} />
       </div>
     {:else if e.entryType === 'system'}
       <div class="row system">

--- a/ui/components/InputBar.svelte
+++ b/ui/components/InputBar.svelte
@@ -281,10 +281,7 @@ Kill a running agent.
       text = '';
       if (textarea) textarea.style.height = 'auto';
       // Resolve alias (e.g. "opus") to real model ID ("claude-opus-4-7")
-      const resolved =
-        provider === 'claude-code'
-          ? CLAUDE_MODEL_ALIASES[arg] ?? arg
-          : arg;
+      const resolved = provider === 'claude-code' ? (CLAUDE_MODEL_ALIASES[arg] ?? arg) : arg;
       await updateSessionModel(sessionId, resolved);
       sessions.update((l) =>
         updateSessionState(l, sessionId, { model: resolved, contextWindow: null })

--- a/ui/components/InputBar.svelte
+++ b/ui/components/InputBar.svelte
@@ -38,6 +38,12 @@
 
   // Model aliases per backend
   const CLAUDE_MODELS = ['opus', 'opus-1m', 'sonnet', 'haiku'];
+  const CLAUDE_MODEL_ALIASES: Record<string, string> = {
+    opus: 'claude-opus-4-7',
+    'opus-1m': 'claude-opus-4-7[1m]',
+    sonnet: 'claude-sonnet-4-6',
+    haiku: 'claude-haiku-4-5-20251001',
+  };
   const CODEX_MODELS = ['gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex', 'gpt-5.2'];
   $: MODEL_OPTIONS =
     provider === 'claude-code'
@@ -265,9 +271,16 @@ Kill a running agent.
       }
       text = '';
       if (textarea) textarea.style.height = 'auto';
-      await updateSessionModel(sessionId, arg);
-      sessions.update((l) => updateSessionState(l, sessionId, { model: arg, contextWindow: null }));
-      emitSystemEntry(`Model changed to ${arg}`);
+      // Resolve alias (e.g. "opus") to real model ID ("claude-opus-4-7")
+      const resolved =
+        provider === 'claude-code'
+          ? CLAUDE_MODEL_ALIASES[arg] ?? arg
+          : arg;
+      await updateSessionModel(sessionId, resolved);
+      sessions.update((l) =>
+        updateSessionState(l, sessionId, { model: resolved, contextWindow: null })
+      );
+      emitSystemEntry(`Model changed to ${resolved}`);
       return;
     }
 

--- a/ui/components/InputBar.svelte
+++ b/ui/components/InputBar.svelte
@@ -37,12 +37,13 @@
   const INTERACTIVE_CMDS = new Set(['/mcp', '/login', '/logout', '/init', '/doctor']);
 
   // Model aliases per backend
-  const CLAUDE_MODELS = ['opus', 'opus-1m', 'sonnet', 'haiku'];
+  const CLAUDE_MODELS = ['opus-4.7', 'opus-4.7-1m', 'opus-4.6', 'sonnet-4.6', 'haiku-4.5'];
   const CLAUDE_MODEL_ALIASES: Record<string, string> = {
-    opus: 'claude-opus-4-7',
-    'opus-1m': 'claude-opus-4-7[1m]',
-    sonnet: 'claude-sonnet-4-6',
-    haiku: 'claude-haiku-4-5-20251001',
+    'opus-4.7': 'claude-opus-4-7',
+    'opus-4.7-1m': 'claude-opus-4-7[1m]',
+    'opus-4.6': 'claude-opus-4-6',
+    'sonnet-4.6': 'claude-sonnet-4-6',
+    'haiku-4.5': 'claude-haiku-4-5-20251001',
   };
   const CODEX_MODELS = ['gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex', 'gpt-5.2'];
   $: MODEL_OPTIONS =

--- a/ui/components/InputBar.svelte
+++ b/ui/components/InputBar.svelte
@@ -37,13 +37,21 @@
   const INTERACTIVE_CMDS = new Set(['/mcp', '/login', '/logout', '/init', '/doctor']);
 
   // Model aliases per backend
-  const CLAUDE_MODELS = ['opus-4.7', 'opus-4.7-1m', 'opus-4.6', 'sonnet-4.6', 'haiku-4.5'];
+  // Display names shown in the picker; resolved to real IDs before sending
+  const CLAUDE_MODELS = ['Opus 4.7', 'Opus 4.7 (1M)', 'Opus 4.6', 'Sonnet 4.6', 'Haiku 4.5'];
   const CLAUDE_MODEL_ALIASES: Record<string, string> = {
+    // Versioned short aliases (also accepted if user types them)
     'opus-4.7': 'claude-opus-4-7',
     'opus-4.7-1m': 'claude-opus-4-7[1m]',
     'opus-4.6': 'claude-opus-4-6',
     'sonnet-4.6': 'claude-sonnet-4-6',
     'haiku-4.5': 'claude-haiku-4-5-20251001',
+    // Display-name aliases (shown in picker)
+    'Opus 4.7': 'claude-opus-4-7',
+    'Opus 4.7 (1M)': 'claude-opus-4-7[1m]',
+    'Opus 4.6': 'claude-opus-4-6',
+    'Sonnet 4.6': 'claude-sonnet-4-6',
+    'Haiku 4.5': 'claude-haiku-4-5-20251001',
   };
   const CODEX_MODELS = ['gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex', 'gpt-5.2'];
   $: MODEL_OPTIONS =

--- a/ui/components/InputBar.svelte
+++ b/ui/components/InputBar.svelte
@@ -45,7 +45,11 @@
       : provider === 'codex'
         ? CODEX_MODELS
         : providerModels;
-  const EFFORT_LEVELS = ['low', 'medium', 'high', 'max'];
+
+  // Effort levels from provider (model-aware) — falls back to global default
+  $: currentModel = $sessions.find((s) => s.id === sessionId)?.model ?? '';
+  $: effortLevels = caps.effortLevels[currentModel] ??
+    caps.effortLevels['auto'] ?? ['low', 'medium', 'high', 'max'];
 
   // Orbit-native commands — provider-aware
   $: modelHint =
@@ -270,8 +274,8 @@ Kill a running agent.
     // Intercept /effort (Claude Code only)
     if (cmd === '/effort' && caps.supportsEffort) {
       const arg = msg.slice(7).trim().toLowerCase();
-      if (!arg || !EFFORT_LEVELS.includes(arg)) {
-        sendError = `Usage: /effort <level> (${EFFORT_LEVELS.join(', ')})`;
+      if (!arg || !effortLevels.includes(arg)) {
+        sendError = `Usage: /effort <level> (${effortLevels.join(', ')})`;
         setTimeout(() => (sendError = ''), 5000);
         return;
       }
@@ -464,6 +468,7 @@ Kill a running agent.
     {providerModels}
     modelOptions={MODEL_OPTIONS}
     supportsEffort={caps.supportsEffort}
+    {effortLevels}
     {files}
     atQuery={aq}
     on:select={handlePickerSelect}

--- a/ui/components/MetaPanel.svelte
+++ b/ui/components/MetaPanel.svelte
@@ -15,6 +15,7 @@
 
   type Tab = 'stats' | 'tasks' | 'agents';
   let tab: Tab = 'stats';
+  $: if (!caps.supportsTasks && tab === 'tasks') tab = 'stats';
 
   let refreshing = false;
 
@@ -51,9 +52,11 @@
     <button class="tab" class:active={tab === 'stats'} on:click={() => (tab = 'stats')}
       >stats</button
     >
-    <button class="tab" class:active={tab === 'tasks'} on:click={() => (tab = 'tasks')}
-      >tasks</button
-    >
+    {#if caps.supportsTasks}
+      <button class="tab" class:active={tab === 'tasks'} on:click={() => (tab = 'tasks')}
+        >tasks</button
+      >
+    {/if}
     <button class="tab" class:active={tab === 'agents'} on:click={() => (tab = 'agents')}
       >agents</button
     >

--- a/ui/components/MetaPanel.svelte
+++ b/ui/components/MetaPanel.svelte
@@ -213,6 +213,7 @@
         sessionId={session.id}
         subagents={session.subagents ?? []}
         {refreshing}
+        cwd={session.cwd}
         onRefresh={refreshAgents}
       />
     {/if}

--- a/ui/components/MetaPanel.svelte
+++ b/ui/components/MetaPanel.svelte
@@ -54,11 +54,9 @@
     <button class="tab" class:active={tab === 'tasks'} on:click={() => (tab = 'tasks')}
       >tasks</button
     >
-    {#if caps.supportsSubagents}
-      <button class="tab" class:active={tab === 'agents'} on:click={() => (tab = 'agents')}
-        >agents</button
-      >
-    {/if}
+    <button class="tab" class:active={tab === 'agents'} on:click={() => (tab = 'agents')}
+      >agents</button
+    >
     <span class="tabs-spacer"></span>
     <button class="collapse-btn" on:click={() => metaPanelVisible.set(false)} title="Hide panel"
       >›</button

--- a/ui/components/Sidebar.svelte
+++ b/ui/components/Sidebar.svelte
@@ -113,50 +113,8 @@
   }
 
   function displayName(s: (typeof $sessions)[0]): string {
-    return s.name ?? s.projectName ?? s.cwd?.split(/[\\/]/).pop() ?? `#${s.id}`;
+    return s.name ?? s.projectName ?? s.cwd?.split(/[/\\]/).pop() ?? `#${s.id}`;
   }
-
-  let collapsedParents: Set<number> = new Set();
-
-  function toggleCollapse(id: number) {
-    if (collapsedParents.has(id)) {
-      collapsedParents.delete(id);
-    } else {
-      collapsedParents.add(id);
-    }
-    collapsedParents = new Set(collapsedParents); // trigger reactivity
-  }
-
-  // Count children per parent
-  $: childCounts = (() => {
-    const counts: Record<number, number> = {};
-    for (const s of $sessions) {
-      if (s.parentSessionId) {
-        counts[s.parentSessionId] = (counts[s.parentSessionId] ?? 0) + 1;
-      }
-    }
-    return counts;
-  })();
-
-  // Group sessions: top-level first, then children nested under parents
-  $: orderedSessions = (() => {
-    const roots = $sessions.filter((s) => !s.parentSessionId);
-    const children = $sessions.filter((s) => s.parentSessionId);
-    const result: (typeof $sessions)[0][] = [];
-    for (const root of roots) {
-      result.push(root);
-      if (!collapsedParents.has(root.id)) {
-        for (const child of children) {
-          if (child.parentSessionId === root.id) result.push(child);
-        }
-      }
-    }
-    // Add orphans (children whose parent isn't loaded)
-    for (const child of children) {
-      if (!roots.some((r) => r.id === child.parentSessionId)) result.push(child);
-    }
-    return result;
-  })();
 </script>
 
 {#if showModal}
@@ -234,15 +192,13 @@
     {#if $sessions.length === 0}
       <p class="empty">no sessions</p>
     {:else}
-      {#each orderedSessions as s (s.id)}
+      {#each $sessions as s (s.id)}
         {@const active = Object.values($workspace.panes).some((p) => p.sessionId === s.id)}
         {@const color = statusColor(s.status)}
         {@const pulsing = isPulsing(s.status)}
-        {@const isChild = !!s.parentSessionId}
         <button
           class="item"
           class:active
-          class:child={isChild}
           draggable="true"
           on:dragstart={(e) => {
             e.dataTransfer?.setData('text/plain', JSON.stringify({ sessionId: s.id }));
@@ -280,18 +236,6 @@
               </span>
             {/if}
             <span class="status" style="color:{color}">{statusLabel(s.status)}</span>
-            {#if childCounts[s.id]}
-              <!-- svelte-ignore a11y_no_static_element_interactions -->
-              <span
-                class="collapse-toggle"
-                on:click|stopPropagation={() => toggleCollapse(s.id)}
-                on:keydown|stopPropagation
-                title={collapsedParents.has(s.id) ? 'Expand sub-agents' : 'Collapse sub-agents'}
-              >
-                <span class="child-count">{childCounts[s.id]}</span>
-                <span class="collapse-arrow" class:collapsed={collapsedParents.has(s.id)}>▾</span>
-              </span>
-            {/if}
           </div>
           <div class="item-meta">
             <span title={s.model ?? ''}>{fmtModel(s.model)}</span>
@@ -442,15 +386,6 @@
     padding-left: var(--sp-5);
   }
 
-  .item.child {
-    padding-left: var(--sp-9);
-    border-left: 2px solid var(--bd);
-  }
-
-  .item.child.active {
-    border-left-color: var(--ac);
-  }
-
   .item-top {
     display: flex;
     align-items: center;
@@ -558,40 +493,6 @@
     font-size: 8px;
     margin-left: var(--sp-2);
     animation: pulse 2s ease-in-out infinite;
-  }
-
-  .collapse-toggle {
-    display: flex;
-    align-items: center;
-    gap: 2px;
-    background: none;
-    border: none;
-    padding: 0 2px;
-    cursor: pointer;
-    color: var(--t3);
-    font-size: 10px;
-    flex-shrink: 0;
-  }
-
-  .collapse-toggle:hover {
-    color: var(--t0);
-  }
-
-  .child-count {
-    background: var(--bg3);
-    border-radius: var(--radius-sm);
-    padding: 0 4px;
-    font-size: 9px;
-    color: var(--t2);
-    line-height: 14px;
-  }
-
-  .collapse-arrow {
-    transition: transform 0.15s;
-  }
-
-  .collapse-arrow.collapsed {
-    transform: rotate(-90deg);
   }
 
   .muted-icon {

--- a/ui/components/SubagentsPanel.svelte
+++ b/ui/components/SubagentsPanel.svelte
@@ -7,6 +7,7 @@
   export let subagents: SubagentInfo[];
   export let refreshing = false;
   export let onRefresh: (() => void) | null = null;
+  export let cwd: string | null = null;
 
   let modalAgent: SubagentInfo | null = null;
   let modalEntries: JournalEntry[] = [];
@@ -113,7 +114,7 @@
         {:else if modalEntries.length === 0}
           <p class="loading">no log entries</p>
         {:else}
-          <Feed entries={modalEntries} status={modalAgent.status} />
+          <Feed entries={modalEntries} status={modalAgent.status} {cwd} />
         {/if}
       </div>
     </div>

--- a/ui/components/TasksList.svelte
+++ b/ui/components/TasksList.svelte
@@ -2,6 +2,7 @@
   import { onMount, onDestroy } from 'svelte';
   import type { TaskItem } from '../lib/types';
   import { getSessionTasks } from '../lib/tauri';
+  import { taskUpdateTrigger } from '../lib/stores/tasks';
 
   export let sessionId: string;
 
@@ -21,6 +22,12 @@
     timer = setInterval(load, 3000);
   });
   onDestroy(() => clearInterval(timer));
+
+  const unsub = taskUpdateTrigger.subscribe((id) => {
+    if (id === Number(sessionId)) load();
+  });
+  onDestroy(() => unsub());
+
   $: if (sessionId) load();
 
   $: done = tasks.filter((t) => t.status === 'completed').length;

--- a/ui/components/ToolCallEntry.svelte
+++ b/ui/components/ToolCallEntry.svelte
@@ -41,6 +41,8 @@
   hljs.registerLanguage('markdown', markdownLang);
   hljs.registerLanguage('svelte', xml);
 
+  import { readFileContent } from '../lib/tauri/files';
+
   type DiffLine = {
     type: 'add' | 'rem' | 'ctx';
     text: string;
@@ -50,6 +52,7 @@
   export let entry: JournalEntry;
   export let resultEntry: JournalEntry | null = null;
   export let streamingEntries: JournalEntry[] = [];
+  export let cwd: string | null = null;
 
   let modalOpen = false;
   let copied = false;
@@ -60,13 +63,32 @@
     setTimeout(() => (copied = false), 1500);
   }
 
-  function getCopyContent(): string {
-    if (hasEditDiff && entry.toolInput?.new_string)
-      return entry.toolInput.new_string as string;
-    if (hasWriteContent && entry.toolInput?.content)
-      return entry.toolInput.content as string;
-    if (hasBashCommand && entry.toolInput?.command)
-      return entry.toolInput.command as string;
+  async function handleCopy() {
+    copyToClipboard(await getCopyContent());
+  }
+
+  function resolveFilePath(filePath: string, cwd: string | null): string {
+    if (!cwd || filePath.startsWith('/') || /^[A-Za-z]:/.test(filePath)) {
+      return filePath;
+    }
+    const base = cwd.replace(/\\/g, '/').replace(/\/$/, '');
+    const p = filePath.replace(/\\/g, '/').replace(/^\//, '');
+    return `${base}/${p}`;
+  }
+
+  async function getCopyContent(): Promise<string> {
+    const filePath = entry.toolInput?.file_path as string | undefined;
+    if (filePath) {
+      const resolved = resolveFilePath(filePath, cwd);
+      try {
+        return await readFileContent(resolved);
+      } catch {
+        // Fallback to inline content if file cannot be read
+      }
+    }
+    if (hasEditDiff && entry.toolInput?.new_string) return entry.toolInput.new_string as string;
+    if (hasWriteContent && entry.toolInput?.content) return entry.toolInput.content as string;
+    if (hasBashCommand && entry.toolInput?.command) return entry.toolInput.command as string;
     if (resultEntry?.output) {
       if (isReadTool) return stripLineNumbers(resultEntry.output).code;
       return resultEntry.output;
@@ -252,9 +274,9 @@
     {#if hasDetail || resultEntry?.output}
       <button
         class="copy-btn"
-        onclick={(e) => {
+        onclick={async (e) => {
           e.stopPropagation();
-          copyToClipboard(getCopyContent());
+          copyToClipboard(await getCopyContent());
         }}
         title={copied ? 'Copiado!' : 'Copiar conteúdo'}
       >
@@ -363,14 +385,16 @@
           <span class="tool {toolClass}">{entry.tool}</span>
           <span class="target mono">{target}</span>
         </div>
-        <button class="modal-close" onclick={() => (modalOpen = false)}>✕</button>
-        <button
-          class="copy-btn modal-copy-btn"
-          onclick={() => copyToClipboard(getCopyContent())}
-          title={copied ? 'Copiado!' : 'Copiar conteúdo'}
-        >
-          <Copy size={13} />
-        </button>
+        <div class="modal-actions">
+          <button
+            class="copy-btn modal-copy-btn"
+            onclick={async () => copyToClipboard(await getCopyContent())}
+            title={copied ? 'Copiado!' : 'Copiar conteúdo'}
+          >
+            <Copy size={13} />
+          </button>
+          <button class="modal-close" onclick={() => (modalOpen = false)}>✕</button>
+        </div>
       </div>
       <div class="modal-body detail">
         {#if hasEditDiff}
@@ -841,6 +865,12 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+  .modal-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-2);
+    flex-shrink: 0;
   }
   .modal-close {
     background: none;

--- a/ui/components/ToolCallEntry.svelte
+++ b/ui/components/ToolCallEntry.svelte
@@ -96,6 +96,11 @@
     return '';
   }
 
+  function getBashOutputContent(): string {
+    if (resultEntry?.output) return resultEntry.output;
+    return '';
+  }
+
   $: toolClass = (entry.tool ?? '').toLowerCase();
   $: target = extractTarget(entry);
   $: timeStr = entry.timestamp.slice(11, 16);
@@ -272,16 +277,39 @@
       </span>
     {/if}
     {#if hasDetail || resultEntry?.output}
-      <button
-        class="copy-btn"
-        onclick={async (e) => {
-          e.stopPropagation();
-          copyToClipboard(await getCopyContent());
-        }}
-        title={copied ? 'Copiado!' : 'Copiar conteúdo'}
-      >
-        <Copy size={11} />
-      </button>
+      {#if hasBashCommand && resultEntry?.output}
+        <button
+          class="copy-btn"
+          onclick={(e) => {
+            e.stopPropagation();
+            copyToClipboard(entry.toolInput!.command as string);
+          }}
+          title="Copiar comando"
+        >
+          <Copy size={11} /> command
+        </button>
+        <button
+          class="copy-btn"
+          onclick={(e) => {
+            e.stopPropagation();
+            copyToClipboard(resultEntry.output!);
+          }}
+          title="Copiar output"
+        >
+          <Copy size={11} /> output
+        </button>
+      {:else}
+        <button
+          class="copy-btn"
+          onclick={async (e) => {
+            e.stopPropagation();
+            copyToClipboard(await getCopyContent());
+          }}
+          title="Copiar conteúdo"
+        >
+          <Copy size={11} /> content
+        </button>
+      {/if}
       <button
         class="expand-btn"
         onclick={(e) => {
@@ -386,13 +414,30 @@
           <span class="target mono">{target}</span>
         </div>
         <div class="modal-actions">
-          <button
-            class="copy-btn modal-copy-btn"
-            onclick={async () => copyToClipboard(await getCopyContent())}
-            title={copied ? 'Copiado!' : 'Copiar conteúdo'}
-          >
-            <Copy size={13} />
-          </button>
+          {#if hasBashCommand && resultEntry?.output}
+            <button
+              class="copy-btn modal-copy-btn"
+              onclick={() => copyToClipboard(entry.toolInput!.command as string)}
+              title="Copiar comando"
+            >
+              <Copy size={13} /> command
+            </button>
+            <button
+              class="copy-btn modal-copy-btn"
+              onclick={() => copyToClipboard(resultEntry.output!)}
+              title="Copiar output"
+            >
+              <Copy size={13} /> output
+            </button>
+          {:else}
+            <button
+              class="copy-btn modal-copy-btn"
+              onclick={async () => copyToClipboard(await getCopyContent())}
+              title="Copiar conteúdo"
+            >
+              <Copy size={13} /> content
+            </button>
+          {/if}
           <button class="modal-close" onclick={() => (modalOpen = false)}>✕</button>
         </div>
       </div>
@@ -570,6 +615,9 @@
 
   .copy-btn {
     flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: var(--sp-1);
     background: var(--bg3);
     border: 1px solid var(--bd1);
     color: var(--t1);

--- a/ui/components/ToolCallEntry.svelte
+++ b/ui/components/ToolCallEntry.svelte
@@ -13,6 +13,7 @@
     Wrench,
     Settings,
     Maximize2,
+    Copy,
   } from 'lucide-svelte';
   import hljs from 'highlight.js/lib/core';
   import javascript from 'highlight.js/lib/languages/javascript';
@@ -51,6 +52,27 @@
   export let streamingEntries: JournalEntry[] = [];
 
   let modalOpen = false;
+  let copied = false;
+
+  function copyToClipboard(text: string) {
+    navigator.clipboard.writeText(text);
+    copied = true;
+    setTimeout(() => (copied = false), 1500);
+  }
+
+  function getCopyContent(): string {
+    if (hasEditDiff && entry.toolInput?.new_string)
+      return entry.toolInput.new_string as string;
+    if (hasWriteContent && entry.toolInput?.content)
+      return entry.toolInput.content as string;
+    if (hasBashCommand && entry.toolInput?.command)
+      return entry.toolInput.command as string;
+    if (resultEntry?.output) {
+      if (isReadTool) return stripLineNumbers(resultEntry.output).code;
+      return resultEntry.output;
+    }
+    return '';
+  }
 
   $: toolClass = (entry.tool ?? '').toLowerCase();
   $: target = extractTarget(entry);
@@ -229,6 +251,16 @@
     {/if}
     {#if hasDetail || resultEntry?.output}
       <button
+        class="copy-btn"
+        onclick={(e) => {
+          e.stopPropagation();
+          copyToClipboard(getCopyContent());
+        }}
+        title={copied ? 'Copiado!' : 'Copiar conteúdo'}
+      >
+        <Copy size={11} />
+      </button>
+      <button
         class="expand-btn"
         onclick={(e) => {
           e.stopPropagation();
@@ -332,6 +364,13 @@
           <span class="target mono">{target}</span>
         </div>
         <button class="modal-close" onclick={() => (modalOpen = false)}>✕</button>
+        <button
+          class="copy-btn modal-copy-btn"
+          onclick={() => copyToClipboard(getCopyContent())}
+          title={copied ? 'Copiado!' : 'Copiar conteúdo'}
+        >
+          <Copy size={13} />
+        </button>
       </div>
       <div class="modal-body detail">
         {#if hasEditDiff}
@@ -503,6 +542,29 @@
     background: var(--bg4);
     color: var(--user-fg);
     border-color: var(--user-fg);
+  }
+
+  .copy-btn {
+    flex-shrink: 0;
+    background: var(--bg3);
+    border: 1px solid var(--bd1);
+    color: var(--t1);
+    font-size: 11px;
+    cursor: pointer;
+    padding: var(--sp-1) var(--sp-3);
+    border-radius: var(--radius-md);
+    line-height: 1;
+    transition: all 0.15s;
+  }
+  .copy-btn:hover {
+    background: var(--bg4);
+    color: var(--user-fg);
+    border-color: var(--user-fg);
+  }
+  .copy-btn:active {
+    background: var(--ac-bg, rgba(0, 212, 126, 0.2));
+    color: var(--ac);
+    border-color: var(--ac);
   }
 
   .detail {
@@ -790,6 +852,14 @@
     border-radius: var(--radius-md);
   }
   .modal-close:hover {
+    background: var(--bg3);
+    color: var(--t0);
+  }
+  .modal-copy-btn {
+    padding: var(--sp-2) var(--sp-4);
+    color: var(--t1);
+  }
+  .modal-copy-btn:hover {
     background: var(--bg3);
     color: var(--t0);
   }

--- a/ui/components/shared/SlashCommandPicker.svelte
+++ b/ui/components/shared/SlashCommandPicker.svelte
@@ -62,14 +62,28 @@
   let subSelIdx = 0;
   let fileSelIdx = 0;
 
+  // Track previous list lengths so we reset the selection only when a list changes,
+  // not on every re-render (which would break arrow-key navigation).
+  let prevSuggestionsLen = -1;
+  let prevSubOptionsLen = -1;
+  let prevFileSuggestionsLen = -1;
+
+  $: if (suggestions.length !== prevSuggestionsLen) {
+    selIdx = 0;
+    prevSuggestionsLen = suggestions.length;
+  }
+  $: if (subOptions.length !== prevSubOptionsLen) {
+    subSelIdx = 0;
+    prevSubOptionsLen = subOptions.length;
+  }
+  $: if (fileSuggestions.length !== prevFileSuggestionsLen) {
+    fileSelIdx = 0;
+    prevFileSuggestionsLen = fileSuggestions.length;
+  }
+
   $: if (selIdx >= suggestions.length) selIdx = 0;
   $: if (subSelIdx >= subOptions.length) subSelIdx = 0;
   $: if (fileSelIdx >= fileSuggestions.length) fileSelIdx = 0;
-
-  // Reset selection indices when the list changes
-  $: if (suggestions.length > 0) selIdx = 0;
-  $: if (subOptions.length > 0) subSelIdx = 0;
-  $: if (fileSuggestions.length > 0) fileSelIdx = 0;
 
   /**
    * Handle keyboard navigation. Returns true if the key was consumed.

--- a/ui/components/shared/SlashCommandPicker.svelte
+++ b/ui/components/shared/SlashCommandPicker.svelte
@@ -8,10 +8,9 @@
   export let providerModels: string[] = [];
   export let modelOptions: string[] = [];
   export let supportsEffort: boolean = false;
+  export let effortLevels: string[] = ['low', 'medium', 'high', 'max'];
   export let files: string[] = [];
   export let atQuery: string | null = null;
-
-  const EFFORT_LEVELS = ['low', 'medium', 'high', 'max'];
 
   const dispatch = createEventDispatcher<{
     select: { type: 'cmd' | 'subOption' | 'file'; value: string };
@@ -28,7 +27,7 @@
       return filtered.slice(0, 10);
     } else if (lower.startsWith('/effort ') && supportsEffort) {
       const arg = lower.slice(8);
-      return EFFORT_LEVELS.filter((o) => o.startsWith(arg));
+      return effortLevels.filter((o) => o.startsWith(arg));
     }
     return [];
   })();

--- a/ui/lib/mock/tauri-mock.ts
+++ b/ui/lib/mock/tauri-mock.ts
@@ -466,13 +466,23 @@ export async function mockInvoke(cmd: string, args?: Record<string, unknown>): P
           supportsEffort: true,
           supportsSsh: true,
           supportsSubagents: true,
+          supportsTasks: true,
           hasSubProviders: false,
           models: [
             { id: 'auto', name: 'auto', context: null, output: null },
+            { id: 'claude-opus-4-7', name: 'opus-4.7', context: 1000000, output: 128000 },
             { id: 'claude-sonnet-4-6', name: 'sonnet-4.6', context: 1000000, output: 64000 },
             { id: 'claude-opus-4-6', name: 'opus-4.6', context: 1000000, output: 128000 },
           ],
           subProviders: [],
+          effortLevels: {
+            'claude-opus-4-7': ['low', 'medium', 'high', 'xhigh', 'max', 'auto'],
+            auto: ['low', 'medium', 'high', 'max'],
+            'claude-opus-4-6': ['low', 'medium', 'high', 'max'],
+            'claude-sonnet-4-6': ['low', 'medium', 'high', 'max'],
+          },
+          taskToolNames: ['TodoWrite'],
+          taskFormat: 'claude_tool_use',
         },
         {
           id: 'codex',
@@ -480,7 +490,8 @@ export async function mockInvoke(cmd: string, args?: Record<string, unknown>): P
           cliAvailable: true,
           supportsEffort: false,
           supportsSsh: true,
-          supportsSubagents: false,
+          supportsSubagents: true,
+          supportsTasks: true,
           hasSubProviders: false,
           models: [
             { id: 'gpt-5.4', name: 'gpt-5.4', context: null, output: null },
@@ -489,6 +500,9 @@ export async function mockInvoke(cmd: string, args?: Record<string, unknown>): P
             { id: 'gpt-5.2', name: 'gpt-5.2', context: null, output: null },
           ],
           subProviders: [],
+          effortLevels: {},
+          taskToolNames: ['todo_list'],
+          taskFormat: 'codex_item_list',
         },
         {
           id: 'opencode',
@@ -497,6 +511,7 @@ export async function mockInvoke(cmd: string, args?: Record<string, unknown>): P
           supportsEffort: false,
           supportsSsh: false,
           supportsSubagents: false,
+          supportsTasks: true,
           hasSubProviders: true,
           models: [],
           subProviders: [
@@ -529,6 +544,9 @@ export async function mockInvoke(cmd: string, args?: Record<string, unknown>): P
               ],
             },
           ],
+          effortLevels: {},
+          taskToolNames: ['todowrite'],
+          taskFormat: 'opencode_tool_use',
         },
       ];
 

--- a/ui/lib/mock/tauri-mock.ts
+++ b/ui/lib/mock/tauri-mock.ts
@@ -426,6 +426,11 @@ export async function mockInvoke(cmd: string, args?: Record<string, unknown>): P
     case 'list_project_files':
       return ['src/index.ts', 'src/auth/auth.ts', 'src/api/routes.ts', 'package.json', 'README.md'];
 
+    case 'read_file_content': {
+      const filePath = args?.path as string;
+      return `// Mock file content for: ${filePath}`;
+    }
+
     case 'update_session_model': {
       const id = args?.sessionId as number;
       const model = args?.model as string;

--- a/ui/lib/status.ts
+++ b/ui/lib/status.ts
@@ -65,6 +65,8 @@ export function isPulsing(status: string): boolean {
 }
 
 const MODEL_NAMES: Record<string, string> = {
+  'claude-opus-4-7': 'Opus 4.7',
+  'claude-opus-4-7[1m]': 'Opus 4.7 (1M)',
   'claude-opus-4-6': 'Opus 4.6',
   'claude-opus-4-6[1m]': 'Opus 4.6 (1M)',
   'claude-sonnet-4-6': 'Sonnet 4.6',

--- a/ui/lib/stores/providers.ts
+++ b/ui/lib/stores/providers.ts
@@ -7,6 +7,7 @@ export interface ProviderCaps {
   supportsEffort: boolean;
   supportsSsh: boolean;
   supportsSubagents: boolean;
+  supportsTasks: boolean;
   hasSubProviders: boolean;
   effortLevels: Record<string, string[]>;
 }
@@ -15,6 +16,7 @@ const DEFAULT_CAPS: ProviderCaps = {
   supportsEffort: false,
   supportsSsh: false,
   supportsSubagents: false,
+  supportsTasks: false,
   hasSubProviders: false,
   effortLevels: {},
 };
@@ -27,6 +29,7 @@ export const providerCaps = derived(backends, ($backends) => {
       supportsEffort: b.supportsEffort,
       supportsSsh: b.supportsSsh,
       supportsSubagents: b.supportsSubagents,
+      supportsTasks: b.supportsTasks,
       hasSubProviders: b.hasSubProviders,
       effortLevels: b.effortLevels,
     });

--- a/ui/lib/stores/providers.ts
+++ b/ui/lib/stores/providers.ts
@@ -8,6 +8,7 @@ export interface ProviderCaps {
   supportsSsh: boolean;
   supportsSubagents: boolean;
   hasSubProviders: boolean;
+  effortLevels: Record<string, string[]>;
 }
 
 const DEFAULT_CAPS: ProviderCaps = {
@@ -15,6 +16,7 @@ const DEFAULT_CAPS: ProviderCaps = {
   supportsSsh: false,
   supportsSubagents: false,
   hasSubProviders: false,
+  effortLevels: {},
 };
 
 /** Map of provider ID → capabilities, derived from the backends list. */
@@ -26,6 +28,7 @@ export const providerCaps = derived(backends, ($backends) => {
       supportsSsh: b.supportsSsh,
       supportsSubagents: b.supportsSubagents,
       hasSubProviders: b.hasSubProviders,
+      effortLevels: b.effortLevels,
     });
   }
   return map;

--- a/ui/lib/stores/tasks.ts
+++ b/ui/lib/stores/tasks.ts
@@ -1,0 +1,5 @@
+import { writable } from 'svelte/store';
+
+/// Emits a sessionId whenever a providers detects a task update in the output stream.
+/// TasksList components can subscribe and reload when their sessionId matches.
+export const taskUpdateTrigger = writable<number | null>(null);

--- a/ui/lib/tauri/events.ts
+++ b/ui/lib/tauri/events.ts
@@ -54,3 +54,7 @@ export function onSessionError(cb: (sessionId: number, error: string) => void) {
 export function onSessionRateLimit(cb: (sessionId: number) => void) {
   return listen<{ sessionId: number }>('session:rate-limit', (e) => cb(e.payload.sessionId));
 }
+
+export function onSessionTaskUpdate(cb: (sessionId: number) => void) {
+  return listen<{ sessionId: number }>('session:task-update', (e) => cb(e.payload.sessionId));
+}

--- a/ui/lib/tauri/files.ts
+++ b/ui/lib/tauri/files.ts
@@ -1,0 +1,5 @@
+import { invoke } from './invoke';
+
+export async function readFileContent(path: string): Promise<string> {
+  return invoke<string>('read_file_content', { path });
+}

--- a/ui/lib/tauri/index.ts
+++ b/ui/lib/tauri/index.ts
@@ -3,3 +3,4 @@ export * from './providers';
 export * from './events';
 export * from './system';
 export * from './projects';
+export * from './files';

--- a/ui/lib/tauri/providers.ts
+++ b/ui/lib/tauri/providers.ts
@@ -27,6 +27,7 @@ export interface CliBackend {
   hasSubProviders: boolean;
   models: ModelInfo[];
   subProviders: SubProvider[];
+  effortLevels: Record<string, string[]>;
 }
 
 export interface SshDiagnostic {

--- a/ui/lib/tauri/providers.ts
+++ b/ui/lib/tauri/providers.ts
@@ -24,10 +24,13 @@ export interface CliBackend {
   supportsEffort: boolean;
   supportsSsh: boolean;
   supportsSubagents: boolean;
+  supportsTasks: boolean;
   hasSubProviders: boolean;
   models: ModelInfo[];
   subProviders: SubProvider[];
   effortLevels: Record<string, string[]>;
+  taskToolNames: string[];
+  taskFormat: string;
 }
 
 export interface SshDiagnostic {


### PR DESCRIPTION
## Summary
- Unified subagent support across all providers (Claude, Codex, ACP, OpenCode)
- File tool calls (Read/Edit/Write) now copy full file content from disk via new read_file_content Tauri command
- Edit tool calls no longer copy only the replacement snippet
- Bash tool calls with output show two separate copy buttons: command and output
- Modal copy button repositioned: Copy left of Close, both right-aligned
- Claude Opus 4.7 support with extended effort levels
- Provider-gated tasks tab (only shown for providers that support tasks)
- Real-time task updates in the tasks panel
- Slash command picker arrow-key navigation fix

## Test Plan
- [x] cargo test (126 passed)
- [x] npm test (22 passed)
