### PR TITLE
fix: parse trailing commas in opencode.jsonc custom providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## April 2026
 
+### 04/23 · Fix — Custom OpenCode servers from opencode.jsonc now appear in the provider list
+Providers defined in `~/.config/opencode/opencode.jsonc` (custom endpoints like CrofAI/Ominiroute) were silently ignored because the JSONC parser did not remove trailing commas before parsing. Now any user-defined provider shows up in the OpenCode provider selector, with configured providers listed first.
+
 ### 04/22 · New — MCP server for multi-agent orchestration
 External AI agents can now create, monitor, and manage Orbit sessions through the Model Context Protocol. When an agent like Claude Code calls `orbit_create_agent`, the spawned session appears live in the dashboard with full journal, tokens, and status tracking. Supports all providers (Claude Code, Codex, OpenCode, Gemini CLI, Copilot CLI).
 

--- a/tauri/src/commands/providers.rs
+++ b/tauri/src/commands/providers.rs
@@ -491,7 +491,53 @@ fn strip_jsonc_comments(s: &str) -> String {
         i += 1;
     }
 
-    out
+    // Second pass: remove trailing commas before `}` or `]`
+    let chars: Vec<char> = out.chars().collect();
+    let len = chars.len();
+    let mut cleaned = String::with_capacity(len);
+    let mut i = 0;
+    let mut in_string = false;
+
+    while i < len {
+        let c = chars[i];
+
+        if in_string {
+            cleaned.push(c);
+            if c == '\\' && i + 1 < len {
+                i += 1;
+                cleaned.push(chars[i]);
+            } else if c == '"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+
+        if c == '"' {
+            in_string = true;
+            cleaned.push(c);
+            i += 1;
+            continue;
+        }
+
+        if c == ',' {
+            // Look ahead past whitespace — if the next non-whitespace char is `}` or `]`,
+            // this is a trailing comma and we drop it
+            let mut j = i + 1;
+            while j < len && chars[j].is_whitespace() {
+                j += 1;
+            }
+            if j < len && (chars[j] == '}' || chars[j] == ']') {
+                i += 1;
+                continue;
+            }
+        }
+
+        cleaned.push(c);
+        i += 1;
+    }
+
+    cleaned
 }
 
 fn read_opencode_jsonc_providers() -> Option<Vec<SubProvider>> {

--- a/ui/components/shared/ProviderSelector.svelte
+++ b/ui/components/shared/ProviderSelector.svelte
@@ -28,8 +28,14 @@
     ? (selectedBackend?.subProviders.find((p) => p.id === subProviderId) ?? null)
     : null;
 
+  // Configured providers first, then alphabetical
+  $: sortedSubProviders = [...(selectedBackend?.subProviders ?? [])].sort((a, b) => {
+    if (a.configured !== b.configured) return a.configured ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+
   // Filtered sub-providers for search
-  $: filteredSubProviders = (selectedBackend?.subProviders ?? []).filter(
+  $: filteredSubProviders = sortedSubProviders.filter(
     (p) =>
       subProviderSearch === '' ||
       p.name.toLowerCase().includes(subProviderSearch.toLowerCase()) ||
@@ -144,7 +150,7 @@
       disabled={loading}
     />
     <div class="sub-list">
-      {#each subProviderSearch ? filteredSubProviders : (selectedBackend?.subProviders ?? []).slice(0, 20) as p}
+      {#each filteredSubProviders as p}
         <button
           class="sub-item"
           class:active={subProviderId === p.id}


### PR DESCRIPTION
## Summary

- The JSONC comment stripper was missing a trailing-comma removal pass, causing `serde_json` to silently reject `opencode.jsonc` files that contain entries like `"field": "value",` before a closing brace (valid JSONC, invalid JSON)
- Added a second pass to `strip_jsonc_comments` that removes trailing commas before `}` or `]`, string-aware so it won't touch commas inside values
- Sorted configured sub-providers to the top of the OpenCode provider list so user-defined entries (e.g. CrofAI/Ominiroute) are immediately visible without needing to scroll or search

## Test plan

- [ ] With a `~/.config/opencode/opencode.jsonc` containing trailing commas and a custom provider (e.g. CrofAI), verify the provider appears at the top of the OpenCode selector
- [ ] Without `opencode.jsonc`, verify the provider list loads normally
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `prettier --check` and `eslint` pass