### PR TITLE
feat: add Glass theme with semi-transparent background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## April 2026
 
+### 04/27 · New — Glass theme with semi-transparent background
+A new Glass theme is now available in the theme picker. It uses semi-transparent
+backgrounds with a dark frosted-glass effect, letting the desktop wallpaper peek
+through the application window. Activate it from the palette icon in the sidebar.
+
 ### 04/24 · Fix — Codex effort changes use the Codex CLI reasoning config
 Changing `/effort` in a Codex session now passes `model_reasoning_effort` through `codex exec --config`, including resumed sessions and the `auto` model path. This avoids relying on a nonexistent `--effort` flag and keeps Codex effort levels aligned with the CLI-supported `low`, `medium`, `high`, and `xhigh` values.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7777,24 +7777,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",

--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -17,6 +17,7 @@
         "height": 750,
         "minWidth": 900,
         "minHeight": 500,
+        "transparent": true,
         "dragDropEnabled": false
       }
     ],

--- a/ui/app.css
+++ b/ui/app.css
@@ -42,10 +42,15 @@ html,
 body {
   height: 100%;
   overflow: hidden;
-  background: var(--bg);
+  background: transparent;
   transition:
     background-color 0.15s ease,
     color 0.15s ease;
+}
+
+[data-theme] html,
+[data-theme] body {
+  background: var(--bg);
 }
 
 body {

--- a/ui/components/ThemePicker.svelte
+++ b/ui/components/ThemePicker.svelte
@@ -132,4 +132,8 @@
   .swatch[data-theme-preview='catppuccin'] {
     background: #1e1e2e;
   }
+  .swatch[data-theme-preview='glass'] {
+    background: rgba(28, 28, 28, 0.88);
+    border-color: rgba(100, 100, 100, 0.55);
+  }
 </style>

--- a/ui/lib/stores/preferences.ts
+++ b/ui/lib/stores/preferences.ts
@@ -1,6 +1,6 @@
 import { writable } from 'svelte/store';
 
-export const THEME_OPTIONS = ['dark', 'light', 'nord', 'dracula', 'catppuccin'] as const;
+export const THEME_OPTIONS = ['dark', 'light', 'nord', 'dracula', 'catppuccin', 'glass'] as const;
 export type Theme = (typeof THEME_OPTIONS)[number];
 
 export const THEME_LABELS: Record<Theme, string> = {
@@ -9,6 +9,7 @@ export const THEME_LABELS: Record<Theme, string> = {
   nord: 'Nord',
   dracula: 'Dracula',
   catppuccin: 'Catppuccin',
+  glass: 'Glass (transparente)',
 };
 
 function applyTheme(value: Theme) {

--- a/ui/themes.css
+++ b/ui/themes.css
@@ -133,6 +133,39 @@
   --result-bg: rgba(248, 248, 242, 0.02);
 }
 
+/* ===== Glass (transparent) ===== */
+[data-theme='glass'] {
+  --bg: rgba(10, 10, 10, 0.55);
+  --bg1: rgba(14, 14, 14, 0.62);
+  --bg2: rgba(20, 20, 20, 0.7);
+  --bg3: rgba(28, 28, 28, 0.78);
+  --bg4: rgba(36, 36, 36, 0.85);
+  --bd: rgba(60, 60, 60, 0.35);
+  --bd1: rgba(80, 80, 80, 0.4);
+  --bd2: rgba(100, 100, 100, 0.45);
+  --t0: #eaeaea;
+  --t1: #a0a0a0;
+  --t2: #707070;
+  --t3: #505050;
+  --ac: #00e090;
+  --ac-d: rgba(0, 224, 144, 0.12);
+  --ac-d2: rgba(0, 224, 144, 0.06);
+  --s-working: #00e090;
+  --s-input: #f0a840;
+  --s-idle: #505050;
+  --s-error: #e85858;
+  --s-init: #5898f0;
+  --s-done: #484848;
+  --user-fg: #8ec4ff;
+  --user-bg: rgba(142, 196, 255, 0.06);
+  --think-fg: #b8a0e8;
+  --think-bg: rgba(184, 160, 232, 0.08);
+  --tool-fg: #f0a840;
+  --tool-bg: rgba(240, 168, 64, 0.06);
+  --result-fg: #707070;
+  --result-bg: rgba(255, 255, 255, 0.03);
+}
+
 /* ===== Catppuccin Mocha ===== */
 [data-theme='catppuccin'] {
   --bg: #1e1e2e;


### PR DESCRIPTION
## Summary

- New **Glass** theme with semi-transparent rgba backgrounds for a frosted-glass effect
- Enables window transparency in Tauri config (transparent: true)
- Available in the theme picker dropdown alongside existing themes
- Background opacity decreases from inner panels (85%) to outer window (55%) for depth