### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,37 @@
 Este arquivo direciona agents ao guia principal do projeto.
 
 👉 **[CLAUDE.md](./CLAUDE.md)** — contem toda a referencia do projeto: stack, estrutura, convencoes, testes, CI, provider system, MCP integration, e mais.
+
+## Cursor Cloud specific instructions
+
+### Environment overview
+
+Orbit is a Tauri 2 desktop app (Rust + SvelteKit). All standard dev commands are in `package.json` (see `CLAUDE.md` for the full table). No external services (Docker, databases, etc.) are required — SQLite is bundled via `rusqlite`.
+
+### Rust toolchain
+
+The `Cargo.toml` declares `rust-version = "1.85"` but some transitive dependencies require a newer Rust. Use `rustup default stable` (1.88+) rather than pinning to 1.85 exactly.
+
+### Building the sidecar before clippy/build
+
+`cargo clippy` and `cargo build` for the main Tauri app will fail if the `orbit-mcp` sidecar binary hasn't been built first (`binaries/orbit-mcp-<triple>` must exist). Run `node scripts/build-sidecar.mjs` (or `npm run build:sidecar`) before any `cargo clippy`/`cargo build` on the workspace. The `npm run tauri:dev` script does this automatically.
+
+### Running the frontend without the Rust backend
+
+Use `npm run dev:mock` to start the Vite dev server (port 1420) with mock Tauri IPC. This is useful for frontend-only development and testing in headless/cloud environments where the native Tauri window cannot open.
+
+### svelte-check requires sync
+
+Run `npx svelte-kit sync` before `npx svelte-check` if the `.svelte-kit/` directory doesn't exist yet. The `npm run check` script handles this automatically.
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Install deps | `npm install` |
+| Lint (all) | `npm run lint` |
+| Frontend tests | `npm test` |
+| Backend tests | `npm run test:rust` |
+| Format check | `npm run format:check` |
+| Dev (full) | `npm run tauri:dev` |
+| Dev (mock) | `npm run dev:mock` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orbit",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orbit",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/tauri/Cargo.lock
+++ b/tauri/Cargo.lock
@@ -2872,7 +2872,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbit"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aes-gcm",
  "agent-client-protocol-schema",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with practical notes for future cloud agents setting up and developing in this codebase:

- Rust toolchain: use `stable` (not just 1.85) due to transitive dependency requirements
- Sidecar binary must be built before `cargo clippy`/`cargo build` 
- `npm run dev:mock` for frontend-only development in headless environments
- `svelte-kit sync` prerequisite for `svelte-check`
- Quick-reference command table

**Demo of the development environment working in mock mode:**

[orbit_mock_mode_demo.mp4](https://cursor.com/agents/bc-f83df2be-a9fb-4698-83bf-492f2d7a48c7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Forbit_mock_mode_demo.mp4)

[Orbit dashboard loaded with mock sessions](https://cursor.com/agents/bc-f83df2be-a9fb-4698-83bf-492f2d7a48c7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Forbit_dashboard_initial.webp)
[New Session modal with configuration options](https://cursor.com/agents/bc-f83df2be-a9fb-4698-83bf-492f2d7a48c7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Forbit_new_session_modal.webp)
[Mock session showing simulated agent output](https://cursor.com/agents/bc-f83df2be-a9fb-4698-83bf-492f2d7a48c7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Forbit_mock_session_output.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f83df2be-a9fb-4698-83bf-492f2d7a48c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f83df2be-a9fb-4698-83bf-492f2d7a48c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

