### PR TITLE
fix(ORB-6): scroll-to-bottom button on the right of the chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## May 2026
 
+### 05/25 · Fix — Scroll to bottom on the right
+When you scroll up in a long session, the "scroll to bottom" button now appears in the bottom-right corner of the chat panel instead of on the left over the timeline.
+
 ### 05/21 · Adjustment — Tighter border-radius, tool card copy buttons, full-width cards
 Cards, inputs, modals, and sidebar items now use smaller border-radius (4px/8px/12px) for a sharper look. Tool cards are full-width with copy buttons for both command and output, each labeled "cmd" and "out". The scroll-to-bottom button sits on the left aligned with the chat timeline. The "working" pill has a subtle pulse animation.
 The dark theme now uses a warmer palette: backgrounds shifted from pure black (#080808) to near-black with subtle warmth (#090a0a), text is now a softer off-white (#f1ece3), borders use translucent warm white (rgba 241,236,227), and the green accent is a calmer tone (#7bd99d). Reading long sessions is now noticeably more comfortable.

--- a/docs/specs/scroll-to-bottom-button.md
+++ b/docs/specs/scroll-to-bottom-button.md
@@ -1,0 +1,43 @@
+# Scroll to bottom button — ORB-6
+
+## Objetivo
+
+O botão flutuante **"↓ scroll to bottom"** deve aparecer no **canto inferior direito** da área do chat, alinhado ao padding horizontal do feed — não à esquerda junto à coluna da timeline.
+
+## Comportamento esperado
+
+- Quando o usuário rola o feed para cima (`atBottom === false`), o botão aparece sobre o conteúdo do chat.
+- Posição: `position: absolute`, `bottom` ~14px (10px em viewport ≤768px), **`right`** alinhado ao padding do timeline (38px desktop, 18px mobile) — espelhando o padding direito de `.timeline` em `Feed.svelte`.
+- Clique: chama `Feed.scrollToBottom()` e oculta o botão quando o feed volta ao fim.
+- O botão não deve sobrepor a coluna de nós da timeline à esquerda nem o input na base do painel.
+
+## Casos de borda
+
+- **Split panes / compact density**: botão permanece ancorado ao `.feed-wrap` do painel ativo (não vaza para o painel vizinho).
+- **Feed vazio ou só mensagens pendentes**: botão não é renderizado (`{#if !atBottom}` dentro de feed com conteúdo).
+- **Redimensionamento / mobile**: `right` reduz para 18px no breakpoint ≤768px, consistente com o padding do timeline em mobile.
+- **Múltiplas sessões**: trocar de sessão recria o `Feed` via `{#key session.id}`; estado `atBottom` reinicia corretamente.
+
+## Critérios de aceitação
+
+1. Com feed longo, após scroll manual para cima, o botão aparece **à direita** do painel central.
+2. O botão **não** aparece alinhado à coluna de timeline (esquerda).
+3. Clicar no botão leva o scroll ao fim e o botão some.
+4. Em layout mobile (≤768px), o botão continua à direita com offset 18px.
+5. Em split view com dois painéis, cada painel mostra seu botão apenas no canto inferior direito **daquele** painel.
+
+## Pontos de teste (manual)
+
+| # | Passo | Resultado esperado |
+|---|--------|-------------------|
+| 1 | Abrir sessão com histórico longo | Feed carrega no fim; botão oculto |
+| 2 | Rolar feed para cima | Botão visível no canto **inferior direito** |
+| 3 | Inspecionar posição vs timeline | Botão não sobrepõe os nós da timeline à esquerda |
+| 4 | Clicar "↓ scroll to bottom" | Scroll no fim; botão desaparece |
+| 5 | Reduzir janela ≤768px, repetir 2–4 | Botão ainda à direita, ~18px da borda |
+| 6 | Abrir split com dois chats, rolar só um | Botão só no painel rolado, canto direito desse painel |
+| 7 | Trocar de sessão na sidebar | Sem botão fantasma; comportamento reinicia na nova sessão |
+
+## Implementação
+
+- Arquivo: `ui/components/CentralPanel.svelte` — classe `.scroll-btn`: usar `right` em vez de `left`.

--- a/ui/components/CentralPanel.svelte
+++ b/ui/components/CentralPanel.svelte
@@ -250,7 +250,7 @@
   .scroll-btn {
     position: absolute;
     bottom: 14px;
-    left: 38px;
+    right: 38px;
     z-index: 10;
     background: var(--bg2);
     border: 1px solid var(--bd1);
@@ -267,7 +267,7 @@
 
   @media (max-width: 768px) {
     .scroll-btn {
-      left: 18px;
+      right: 18px;
       bottom: 10px;
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [ORB-6](https://linear.app) — the floating **"↓ scroll to bottom"** button was positioned on the left (aligned with the timeline column). It now sits in the **bottom-right** of the chat panel, matching the feed's horizontal padding.

## Changes

- `CentralPanel.svelte`: `.scroll-btn` uses `right: 38px` (desktop) and `right: 18px` (≤768px) instead of `left`
- `docs/specs/scroll-to-bottom-button.md`: spec with behavior, edge cases, acceptance criteria, and manual test checklist
- `CHANGELOG.md`: user-facing fix entry

## How to test

1. Open a session with a long feed
2. Scroll up — button appears in the **bottom-right** corner
3. Click the button — feed scrolls to end and button hides
4. Repeat on a narrow window (≤768px) and in split-pane layout

## Verification

- `npx prettier --check` on changed Svelte file
- `npx eslint` — pass
- `npx svelte-check --fail-on-warnings` — 0 errors/warnings
- `npm test` — 147 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ORB-6](https://linear.app/aiorbit/issue/ORB-6/scroll-to-bottom-devem-ficar-a-direita-e-nao-a-esquerda-do-chat)

<div><a href="https://cursor.com/agents/bc-c5bd688e-1a64-4163-8517-ac4b30ffb7ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5bd688e-1a64-4163-8517-ac4b30ffb7ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

