### PR TITLE
fix: sidebar session search filters pinned and recent lists (ORB-7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## May 2026
 
+### 05/25 · Fix — Sidebar session search works
+The Search sessions field in the sidebar is now a real search box. Typing filters pinned and recent sessions by name, project, folder, branch, model, and status. Clear the field to show every session again.
+
 ### 05/21 · Adjustment — Tighter border-radius, tool card copy buttons, full-width cards
 Cards, inputs, modals, and sidebar items now use smaller border-radius (4px/8px/12px) for a sharper look. Tool cards are full-width with copy buttons for both command and output, each labeled "cmd" and "out". The scroll-to-bottom button sits on the left aligned with the chat timeline. The "working" pill has a subtle pulse animation.
 The dark theme now uses a warmer palette: backgrounds shifted from pure black (#080808) to near-black with subtle warmth (#090a0a), text is now a softer off-white (#f1ece3), borders use translucent warm white (rgba 241,236,227), and the green accent is a calmer tone (#7bd99d). Reading long sessions is now noticeably more comfortable.

--- a/docs/specs/sidebar-session-search.md
+++ b/docs/specs/sidebar-session-search.md
@@ -1,0 +1,42 @@
+# Spec: Sidebar session search (ORB-7)
+
+## Objective
+
+Make the sidebar "Search sessions" control filter the pinned and recent session lists in real time.
+
+## Problem
+
+The Quiet Console sidebar shows a non-interactive placeholder (`<div>`) styled like a search field. Users cannot type or filter sessions.
+
+## Expected behavior
+
+1. The control is a text `<input>` with placeholder "Search sessions…".
+2. Typing filters both **Pinned** and **Recent sessions** lists (case-insensitive substring match).
+3. A session matches if any of these fields contain the query (trimmed): display name, project name, folder name from `cwd`, branch (`branchName` or `gitBranch`), model, provider id, status.
+4. Empty query shows all sessions (current behavior).
+5. When the query is non-empty and no root session matches, show **No matching sessions** in the recent section (pinned section hidden if empty).
+6. Pinned section is hidden when there are no pinned matches (same as today when no pinned sessions).
+
+## Edge cases
+
+| Case | Result |
+|------|--------|
+| Whitespace-only query | Treated as empty (show all) |
+| Child sessions (`parentSessionId` set) | Not listed in sidebar; search only applies to root sessions |
+| All roots pinned, search matches none | "No matching sessions" |
+| Search matches only pinned | Recent area shows "No matching sessions" or empty recent list message |
+
+## Acceptance criteria
+
+- [ ] Input accepts keyboard focus and text entry
+- [ ] Filtering updates lists as the user types
+- [ ] Clearing the input restores the full list
+- [ ] Vitest covers filter behavior via `data-testid="session-search-input"`
+
+## Test points (manual)
+
+1. Create 3+ sessions with distinct names; type part of one name — only matching cards remain.
+2. Search by git branch label shown in subline — matching session appears.
+3. Clear search — all sessions return.
+4. Search gibberish — "No matching sessions" appears.
+5. Pin a session; search a non-pinned name — pinned section hides if no pin matches.

--- a/ui/components/Sidebar.component.test.ts
+++ b/ui/components/Sidebar.component.test.ts
@@ -275,4 +275,51 @@ describe('Sidebar', () => {
     expect(getByText(/drag sessions into panes/i)).toBeTruthy();
     expect(getByText(/⌘I inspect/i)).toBeTruthy();
   });
+
+  // ── Session search ──
+
+  it('session search input accepts text and filters the list', async () => {
+    mockSessionsStore.set([
+      makeSession({ id: 1, name: 'Billing refactor' }),
+      makeSession({ id: 2, name: 'Auth migration' }),
+    ]);
+
+    const { getByTestId, getByText, queryByText } = render(Sidebar);
+    const search = getByTestId('session-search-input') as HTMLInputElement;
+
+    expect(getByText('Billing refactor')).toBeTruthy();
+    expect(getByText('Auth migration')).toBeTruthy();
+
+    await fireEvent.input(search, { target: { value: 'billing' } });
+
+    expect(getByText('Billing refactor')).toBeTruthy();
+    expect(queryByText('Auth migration')).toBeNull();
+  });
+
+  it('session search shows empty state when nothing matches', async () => {
+    mockSessionsStore.set([makeSession({ id: 1, name: 'Only session' })]);
+
+    const { getByTestId, getByText, queryByText } = render(Sidebar);
+    const search = getByTestId('session-search-input') as HTMLInputElement;
+
+    await fireEvent.input(search, { target: { value: 'zzznomatch' } });
+
+    expect(queryByText('Only session')).toBeNull();
+    expect(getByText('No matching sessions')).toBeTruthy();
+  });
+
+  it('session search by branch label filters sessions', async () => {
+    mockSessionsStore.set([
+      makeSession({ id: 1, name: 'Alpha', gitBranch: 'feature/payments' }),
+      makeSession({ id: 2, name: 'Beta', gitBranch: 'main' }),
+    ]);
+
+    const { getByTestId, getByText, queryByText } = render(Sidebar);
+    const search = getByTestId('session-search-input') as HTMLInputElement;
+
+    await fireEvent.input(search, { target: { value: 'payments' } });
+
+    expect(getByText('Alpha')).toBeTruthy();
+    expect(queryByText('Beta')).toBeNull();
+  });
 });

--- a/ui/components/Sidebar.svelte
+++ b/ui/components/Sidebar.svelte
@@ -138,12 +138,43 @@
     return s.name ?? s.projectName ?? s.cwd?.split(/[/\\]/).pop() ?? `#${s.id}`;
   }
 
+  let searchQuery = '';
+
+  function sessionSearchHaystack(s: (typeof $sessions)[0]): string {
+    const branch = s.branchName ?? s.gitBranch ?? '';
+    const cwdLeaf = s.cwd?.split(/[/\\]/).pop() ?? '';
+    return [
+      displayName(s),
+      s.name,
+      s.projectName,
+      cwdLeaf,
+      s.cwd,
+      branch,
+      s.model,
+      s.provider,
+      s.status,
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase();
+  }
+
+  function matchesSessionSearch(s: (typeof $sessions)[0], query: string): boolean {
+    const q = query.trim().toLowerCase();
+    if (!q) return true;
+    return sessionSearchHaystack(s).includes(q);
+  }
+
   // Derived lists for session sections
   $: rootSessions = $sessions.filter((s) => !s.parentSessionId);
-  $: pinnedList = rootSessions.filter((s) =>
+  $: searchActive = searchQuery.trim().length > 0;
+  $: filteredRoots = searchActive
+    ? rootSessions.filter((s) => matchesSessionSearch(s, searchQuery))
+    : rootSessions;
+  $: pinnedList = filteredRoots.filter((s) =>
     pinnedSessions.isPinned($pinnedSessions, String(s.id))
   );
-  $: recentList = rootSessions.filter(
+  $: recentList = filteredRoots.filter(
     (s) => !pinnedSessions.isPinned($pinnedSessions, String(s.id))
   );
 </script>
@@ -226,7 +257,16 @@
     </div>
   </header>
 
-  <div class="quiet-search" aria-label="Search sessions">Search sessions…</div>
+  <input
+    type="search"
+    class="quiet-search"
+    bind:value={searchQuery}
+    placeholder="Search sessions…"
+    aria-label="Search sessions"
+    data-testid="session-search-input"
+    autocomplete="off"
+    spellcheck="false"
+  />
 
   <button
     type="button"
@@ -282,8 +322,12 @@
     <div class="session-list">
       {#if rootSessions.length === 0}
         <div class="empty quiet-empty">No sessions yet</div>
+      {:else if searchActive && filteredRoots.length === 0}
+        <div class="empty quiet-empty">No matching sessions</div>
       {:else if recentList.length === 0}
-        <div class="empty quiet-empty">All sessions pinned</div>
+        <div class="empty quiet-empty">
+          {searchActive ? 'No matching sessions' : 'All sessions pinned'}
+        </div>
       {:else}
         {#each recentList as s (s.id)}
           {@const hasChildren = getChildren($sessions, s.id).length > 0}
@@ -413,14 +457,24 @@
     color: var(--t0);
   }
   .quiet-search {
+    width: 100%;
     height: 34px;
-    display: flex;
-    align-items: center;
+    box-sizing: border-box;
     padding: 0 12px;
+    border: 1px solid transparent;
     border-radius: var(--radius-md);
     background: color-mix(in srgb, var(--t0), transparent 95%);
-    color: var(--t3);
+    color: var(--t0);
     font-size: 12px;
+    font-family: inherit;
+    outline: none;
+  }
+  .quiet-search::placeholder {
+    color: var(--t3);
+  }
+  .quiet-search:focus {
+    border-color: color-mix(in srgb, var(--t0), transparent 88%);
+    background: color-mix(in srgb, var(--t0), transparent 93%);
   }
   .session-section {
     display: flex;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes **ORB-7** — the sidebar "Search sessions" control was a static placeholder and did not accept input or filter sessions.

## Changes

- Replace the placeholder `<div>` with a real `<input type="search">` bound to `searchQuery`
- Filter **Pinned** and **Recent sessions** as the user types (case-insensitive match on name, project, cwd, branch, model, provider, status)
- Show **No matching sessions** when a non-empty query matches nothing
- Add Vitest coverage for filtering by name and branch
- Spec: `docs/specs/sidebar-session-search.md`

## Test plan

- [x] `npm run test:components -- ui/components/Sidebar.component.test.ts` (8 tests)
- [ ] Manual: type in sidebar search; list narrows; clear restores full list
- [ ] Manual: search by branch label in session subline

## Linear

ORB-7
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ORB-7](https://linear.app/aiorbit/issue/ORB-7/search-sessions-input-da-sidebar-nao-funciona)

<div><a href="https://cursor.com/agents/bc-8aa53327-8e0b-43eb-be1f-80c52b4c6385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8aa53327-8e0b-43eb-be1f-80c52b4c6385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

