### PR TITLE
fix(ORB-5): OS-aware keyboard shortcut hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## May 2026
 
+### 05/25 · Fix — Keyboard shortcut hints match your operating system
+Shortcut hints in the sidebar footer, inspector badge, and browse buttons now show Ctrl on Windows and Linux instead of macOS Command (⌘) symbols. Inspector toggle still works with Ctrl+I on Windows as before.
+
 ### 05/21 · Adjustment — Tighter border-radius, tool card copy buttons, full-width cards
 Cards, inputs, modals, and sidebar items now use smaller border-radius (4px/8px/12px) for a sharper look. Tool cards are full-width with copy buttons for both command and output, each labeled "cmd" and "out". The scroll-to-bottom button sits on the left aligned with the chat timeline. The "working" pill has a subtle pulse animation.
 The dark theme now uses a warmer palette: backgrounds shifted from pure black (#080808) to near-black with subtle warmth (#090a0a), text is now a softer off-white (#f1ece3), borders use translucent warm white (rgba 241,236,227), and the green accent is a calmer tone (#7bd99d). Reading long sessions is now noticeably more comfortable.

--- a/docs/specs/os-shortcut-hints.md
+++ b/docs/specs/os-shortcut-hints.md
@@ -1,0 +1,52 @@
+# OS-aware shortcut hints — ORB-5
+
+**Issue:** ORB-5  
+**Status:** Implemented
+
+---
+
+## Objetivo
+
+Exibir hints de atalhos de teclado de acordo com o sistema operacional do usuário. No Windows e Linux, usar `Ctrl`; no macOS, usar `⌘` (Command).
+
+---
+
+## Comportamento esperado
+
+| Contexto | macOS | Windows / Linux |
+|----------|-------|-----------------|
+| Toggle inspector | `⌘I` | `Ctrl+I` |
+| Split pane (footer) | `⌘\ split` | `Ctrl+\ split` |
+| Sidebar footer | `… • ⌘\ split • ⌘I inspect` | `… • Ctrl+\ split • Ctrl+I inspect` |
+| Botão browse (pasta/chave) | `⌘` (legado) | `…` |
+| Handler real (App) | `metaKey \|\| ctrlKey` | idem |
+
+A detecção usa `navigator.platform` / `userAgent` no WebView do Tauri (mesmo padrão de `TerminalPanel.svelte`).
+
+---
+
+## Casos de borda
+
+- **Mock / Vitest / SSR:** sem `navigator` → tratar como não-mac (`Ctrl`).
+- **Linux no Mac hardware:** segue `navigator`, não hardware.
+- **Web build:** mesma heurística do browser.
+- **Submit com Enter no NewSessionModal:** `metaKey` sozinho não dispara em Windows; usar `metaKey || ctrlKey`.
+
+---
+
+## Critérios de aceitação
+
+1. Em ambiente Windows (ou teste com `platform: Win32`), footer da sidebar e badge do inspector mostram `Ctrl+I` e `Ctrl+\`, nunca `⌘`.
+2. Em ambiente macOS (ou teste com `platform: MacIntel`), continuam mostrando `⌘I` e `⌘\`.
+3. `App.svelte` continua alternando o inspector com Ctrl+I no Windows (já funcionava).
+4. Testes unitários cobrem formatação para mac e windows.
+
+---
+
+## Pontos de teste manual
+
+1. **Windows:** abrir Orbit → sidebar footer deve mostrar `Ctrl+\` e `Ctrl+I`; badge “inspector hidden” deve mostrar `Ctrl+I`.
+2. **Windows:** pressionar `Ctrl+I` → painel direito abre/fecha.
+3. **macOS:** mesmos textos com `⌘`; `⌘I` alterna o inspector.
+4. **New session modal:** `Ctrl+Enter` no prompt (Windows) envia o formulário quando preenchido.
+5. **Browse:** botão ao lado do path em nova sessão mostra `…` no Windows (não `⌘`).

--- a/ui/components/CentralPanel.svelte
+++ b/ui/components/CentralPanel.svelte
@@ -7,6 +7,7 @@
   import { updateSessionState, sessions } from '../lib/stores/sessions';
   import { statusColor, statusLabel, modelShortName } from '../lib/status';
   import { metaPanelVisible, compactDensity } from '../lib/stores/preferences';
+  import { inspectorToggleHint } from '../lib/shortcuts';
   import Feed from './Feed.svelte';
   import InputBar from './InputBar.svelte';
   import PanelHeader from './workspace/PanelHeader.svelte';
@@ -130,7 +131,7 @@
       on:keydown={(e) => e.key === 'Enter' && metaPanelVisible.set(true)}
       title="Toggle inspector panel"
     >
-      inspector hidden • ⌘I
+      inspector hidden • {inspectorToggleHint()}
     </div>
   {/if}
 

--- a/ui/components/NewSessionModal.svelte
+++ b/ui/components/NewSessionModal.svelte
@@ -10,6 +10,7 @@
   import Modal from './shared/Modal.svelte';
   import ProviderSelector from './shared/ProviderSelector.svelte';
   import SshFields from './shared/SshFields.svelte';
+  import { browseButtonLabel } from '../lib/shortcuts';
 
   const dispatch = createEventDispatcher<{
     done: { session: Session };
@@ -206,7 +207,9 @@
         on:keydown={(e) => e.key === 'Enter' && prompt && submit()}
       />
       {#if !sshMode}
-        <button class="browse" on:click={browse} disabled={loading} title="browse">⌘</button>
+        <button class="browse" on:click={browse} disabled={loading} title="browse"
+          >{browseButtonLabel()}</button
+        >
       {/if}
     </div>
   </div>
@@ -222,7 +225,7 @@
       rows="3"
       disabled={loading}
       on:keydown={(e) => {
-        if (e.key === 'Enter' && e.metaKey) submit();
+        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) submit();
       }}
     ></textarea>
   </div>

--- a/ui/components/Sidebar.component.test.ts
+++ b/ui/components/Sidebar.component.test.ts
@@ -273,6 +273,6 @@ describe('Sidebar', () => {
     mockSessionsStore.set([makeSession({ id: 1, name: 'One' })]);
     const { getByText } = render(Sidebar);
     expect(getByText(/drag sessions into panes/i)).toBeTruthy();
-    expect(getByText(/⌘I inspect/i)).toBeTruthy();
+    expect(getByText(/(?:⌘|Ctrl\+)I inspect/i)).toBeTruthy();
   });
 });

--- a/ui/components/Sidebar.svelte
+++ b/ui/components/Sidebar.svelte
@@ -12,6 +12,7 @@
   import { modelShortName } from '../lib/status';
   import { onMount } from 'svelte';
   import { clearAttention } from '../lib/tauri/attention';
+  import { workspaceShortcutsFooter } from '../lib/shortcuts';
 
   function attentionColor(reason: string | null): string {
     switch (reason) {
@@ -322,7 +323,7 @@
     </div>
   </section>
 
-  <footer class="footer quiet-footer">drag sessions into panes • ⌘\ split • ⌘I inspect</footer>
+  <footer class="footer quiet-footer">{workspaceShortcutsFooter()}</footer>
 </aside>
 
 <style>

--- a/ui/components/shared/SshFields.svelte
+++ b/ui/components/shared/SshFields.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { HAS_TAURI } from '../../lib/tauri/invoke';
+  import { browseButtonLabel } from '../../lib/shortcuts';
 
   export let sshHost: string;
   export let sshUser: string;
@@ -56,7 +57,9 @@
       placeholder="~/.ssh/id_rsa"
       disabled={loading}
     />
-    <button class="browse" on:click={browseKey} disabled={loading} title="browse">⌘</button>
+    <button class="browse" on:click={browseKey} disabled={loading} title="browse"
+      >{browseButtonLabel()}</button
+    >
   </div>
 </div>
 

--- a/ui/lib/shortcuts.test.ts
+++ b/ui/lib/shortcuts.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  browseButtonLabel,
+  detectPlatform,
+  formatModChord,
+  inspectorToggleHint,
+  isMacOS,
+  modKeyLabel,
+  splitPaneHint,
+  workspaceShortcutsFooter,
+} from './shortcuts';
+
+function mockNavigator(platform: string, userAgent = '') {
+  vi.stubGlobal('navigator', {
+    platform,
+    userAgent,
+  });
+}
+
+describe('shortcuts', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('detects macOS', () => {
+    mockNavigator('MacIntel', 'Mozilla/5.0 (Macintosh; Intel Mac OS X)');
+    expect(detectPlatform()).toBe('mac');
+    expect(isMacOS()).toBe(true);
+  });
+
+  it('detects Windows', () => {
+    mockNavigator('Win32', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
+    expect(detectPlatform()).toBe('windows');
+    expect(isMacOS()).toBe(false);
+  });
+
+  it('formats inspector hint for macOS', () => {
+    mockNavigator('MacIntel');
+    expect(inspectorToggleHint()).toBe('⌘I');
+    expect(modKeyLabel()).toBe('⌘');
+  });
+
+  it('formats inspector hint for Windows', () => {
+    mockNavigator('Win32');
+    expect(inspectorToggleHint()).toBe('Ctrl+I');
+    expect(modKeyLabel()).toBe('Ctrl');
+  });
+
+  it('formats split pane hint per platform', () => {
+    mockNavigator('MacIntel');
+    expect(splitPaneHint()).toBe('⌘\\');
+
+    mockNavigator('Win32');
+    expect(splitPaneHint()).toBe('Ctrl+\\');
+  });
+
+  it('builds workspace footer with platform-specific chords', () => {
+    mockNavigator('Win32');
+    expect(workspaceShortcutsFooter()).toContain('Ctrl+\\');
+    expect(workspaceShortcutsFooter()).toContain('Ctrl+I');
+    expect(workspaceShortcutsFooter()).not.toContain('⌘');
+  });
+
+  it('browse button uses ellipsis off macOS', () => {
+    mockNavigator('Win32');
+    expect(browseButtonLabel()).toBe('…');
+
+    mockNavigator('MacIntel');
+    expect(browseButtonLabel()).toBe('⌘');
+  });
+
+  it('formatModChord supports custom separator', () => {
+    mockNavigator('Win32');
+    expect(formatModChord('S', '+')).toBe('Ctrl+S');
+  });
+
+  it('defaults to non-mac when navigator is missing', () => {
+    vi.stubGlobal('navigator', undefined);
+    expect(isMacOS()).toBe(false);
+    expect(inspectorToggleHint()).toBe('Ctrl+I');
+  });
+});

--- a/ui/lib/shortcuts.ts
+++ b/ui/lib/shortcuts.ts
@@ -1,0 +1,44 @@
+export type ShortcutPlatform = 'mac' | 'windows' | 'linux' | 'other';
+
+/** Detect OS for shortcut label formatting (WebView / browser). */
+export function detectPlatform(): ShortcutPlatform {
+  if (typeof navigator === 'undefined') return 'other';
+  const platform = navigator.platform?.toLowerCase() ?? '';
+  const ua = navigator.userAgent?.toLowerCase() ?? '';
+  if (platform.includes('mac') || ua.includes('mac')) return 'mac';
+  if (platform.startsWith('win') || ua.includes('windows')) return 'windows';
+  if (platform.includes('linux') || ua.includes('linux')) return 'linux';
+  return 'other';
+}
+
+export function isMacOS(): boolean {
+  return detectPlatform() === 'mac';
+}
+
+/** Modifier label shown in UI hints: ⌘ on macOS, Ctrl elsewhere. */
+export function modKeyLabel(): string {
+  return isMacOS() ? '⌘' : 'Ctrl';
+}
+
+/** Chord hint such as mod+I → ⌘I (mac) or Ctrl+I (Windows/Linux). */
+export function formatModChord(key: string, separator?: string): string {
+  const sep = separator ?? (isMacOS() ? '' : '+');
+  return `${modKeyLabel()}${sep}${key}`;
+}
+
+export function inspectorToggleHint(): string {
+  return formatModChord('I');
+}
+
+export function splitPaneHint(): string {
+  return isMacOS() ? '⌘\\' : 'Ctrl+\\';
+}
+
+export function workspaceShortcutsFooter(): string {
+  return `drag sessions into panes • ${splitPaneHint()} split • ${inspectorToggleHint()} inspect`;
+}
+
+/** Browse affordance on path/key fields (not a keyboard shortcut). */
+export function browseButtonLabel(): string {
+  return isMacOS() ? '⌘' : '…';
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [ORB-5](https://linear.app) — shortcut hints in the UI showed macOS `⌘` symbols on Windows.

## Changes

- Added `ui/lib/shortcuts.ts` to detect platform via `navigator` and format hints (`⌘I` vs `Ctrl+I`, `⌘\` vs `Ctrl+\`).
- Updated **Sidebar** footer, **CentralPanel** inspector badge, and **browse** buttons in New Session / SSH fields.
- **NewSessionModal**: `Ctrl+Enter` now submits on Windows/Linux (was `metaKey` only).
- Spec: `docs/specs/os-shortcut-hints.md` with acceptance criteria and manual test points.
- Unit tests in `ui/lib/shortcuts.test.ts`.

## Manual test (Windows)

1. Sidebar footer shows `Ctrl+\ split • Ctrl+I inspect` (no `⌘`).
2. Inspector badge shows `Ctrl+I` when panel is hidden.
3. `Ctrl+I` toggles the inspector panel.
4. Browse button next to path shows `…` instead of `⌘`.
5. `Ctrl+Enter` in new session prompt submits when filled.

## Manual test (macOS)

1. Hints still show `⌘\` and `⌘I`.
2. `⌘I` toggles inspector; browse button shows `⌘`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ORB-5](https://linear.app/aiorbit/issue/ORB-5/hints-de-atalhos-nao-estao-respeitando-as-respectivas-os-estou-no)

<div><a href="https://cursor.com/agents/bc-2e2fcd82-262a-467d-878a-4b67551448d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e2fcd82-262a-467d-878a-4b67551448d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

