### PR TITLE
feat(ORB-12): Incorporate Glass Tier chrome into Quiet Journal UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## May 2026
 
+### 05/25 · Improvement — Glass Tier chrome on tabs and panel headers
+Workspace tabs and panel headers now use the translucent Glass Tier look from the earlier Orbit mock: frosted tab bars with blur, rounded active tabs with a soft accent glow, compact headers with a status dot, and matching glass surfaces on the Git file tree and diff bar.
+
 ### 05/21 · Adjustment — Tighter border-radius, tool card copy buttons, full-width cards
 Cards, inputs, modals, and sidebar items now use smaller border-radius (4px/8px/12px) for a sharper look. Tool cards are full-width with copy buttons for both command and output, each labeled "cmd" and "out". The scroll-to-bottom button sits on the left aligned with the chat timeline. The "working" pill has a subtle pulse animation.
 The dark theme now uses a warmer palette: backgrounds shifted from pure black (#080808) to near-black with subtle warmth (#090a0a), text is now a softer off-white (#f1ece3), borders use translucent warm white (rgba 241,236,227), and the green accent is a calmer tone (#7bd99d). Reading long sessions is now noticeably more comfortable.

--- a/ui/components/GitPanel.svelte
+++ b/ui/components/GitPanel.svelte
@@ -395,10 +395,13 @@
     align-items: center;
     gap: 8px;
     padding: 4px 10px;
-    border-bottom: 1px solid var(--bd);
-    background: var(--bg2);
+    border-bottom: 1px solid var(--glass-border-subtle);
+    background: var(--glass-bg-subtle);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: 9px;
+    color: color-mix(in srgb, var(--t0), transparent 55%);
     flex-shrink: 0;
   }
 
@@ -473,7 +476,10 @@
     min-width: 0;
     min-height: 0;
     flex-direction: column;
-    border-right: 1px solid var(--bd);
+    border-right: 1px solid var(--glass-border);
+    background: var(--glass-bg-tree);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
     margin-right: 4px;
   }
 
@@ -483,15 +489,15 @@
 
   .tree-tools {
     padding: 6px 8px;
-    border-bottom: 1px solid var(--bd);
+    border-bottom: 1px solid var(--glass-border-subtle);
   }
 
   .tree-tools input {
     width: 100%;
     height: 24px;
-    border: 1px solid var(--bd);
+    border: 1px solid var(--glass-border);
     border-radius: var(--radius-sm);
-    background: var(--bg1);
+    background: var(--glass-bg);
     color: var(--t2);
     padding: 0 8px;
     font-family: var(--mono);
@@ -533,7 +539,7 @@
     align-items: center;
     height: 28px;
     padding: 0 10px;
-    border-bottom: 1px solid var(--bd);
+    border-bottom: 1px solid var(--glass-border-subtle);
     color: var(--t2);
     font-size: 9.5px;
     font-family: var(--mono);

--- a/ui/components/GitTreeNode.svelte
+++ b/ui/components/GitTreeNode.svelte
@@ -120,15 +120,16 @@
   }
 
   .tree-row:hover {
-    background: rgba(255, 255, 255, 0.03);
+    background: var(--glass-bg-subtle);
   }
 
   .folder-row {
-    color: #d9f7e8;
+    color: color-mix(in srgb, var(--t0), transparent 35%);
   }
 
   .file-row.selected {
-    background: rgba(0, 212, 126, 0.06);
+    background: var(--glass-tab-active-bg);
+    color: color-mix(in srgb, var(--t0), transparent 50%);
   }
 
   .expand-btn,

--- a/ui/components/workspace/PanelHeader.component.test.ts
+++ b/ui/components/workspace/PanelHeader.component.test.ts
@@ -3,18 +3,20 @@ import { render, fireEvent } from '@testing-library/svelte';
 import PanelHeader from './PanelHeader.svelte';
 
 describe('PanelHeader', () => {
-  it('renders quiet pane header title, status, and close button', async () => {
+  it('renders glass pane header title, status dot, and close button', async () => {
     const onClose = vi.fn();
     const { getByText, getByLabelText, container } = render(PanelHeader, {
       props: {
         title: 'Refactor billing flow',
         status: 'running',
+        statusColor: '#7cff9e',
         onClose,
         focused: true,
       },
     });
 
-    expect(container.querySelector('header.quiet-topbar')).toBeTruthy();
+    expect(container.querySelector('header.glass-topbar')).toBeTruthy();
+    expect(container.querySelector('.status-dot')).toBeTruthy();
     expect(getByText('Refactor billing flow')).toBeTruthy();
     expect(getByText('running')).toBeTruthy();
     await fireEvent.click(getByLabelText('Close panel'));

--- a/ui/components/workspace/PanelHeader.svelte
+++ b/ui/components/workspace/PanelHeader.svelte
@@ -9,8 +9,11 @@
   export let focused: boolean = true;
 </script>
 
-<header class="topbar quiet-topbar" class:focused>
+<header class="topbar glass-topbar" class:focused>
   <div class="crumb">
+    {#if statusColor}
+      <span class="status-dot" style="background: {statusColor}" aria-hidden="true"></span>
+    {/if}
     <span class="crumb-title" {title}>{title}</span>
     {#if meta}
       <span class="crumb-meta" title={meta}>{meta}</span>
@@ -42,10 +45,12 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    height: 58px;
-    padding: 0 24px;
-    border-bottom: 1px solid var(--bd);
-    background: rgba(255, 255, 255, 0.006);
+    height: 36px;
+    padding: 0 10px;
+    border-bottom: 1px solid var(--glass-border-subtle);
+    background: var(--glass-bg-subtle);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
     flex-shrink: 0;
     user-select: none;
     min-width: 0;
@@ -60,14 +65,24 @@
   .crumb {
     display: flex;
     align-items: center;
-    gap: 10px;
+    gap: 8px;
     min-width: 0;
     overflow: hidden;
   }
+
+  .status-dot {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    box-shadow: 0 0 8px color-mix(in srgb, currentColor, transparent 40%);
+  }
+
   .crumb-title {
-    font-weight: 700;
-    letter-spacing: -0.02em;
-    color: var(--t0);
+    font-weight: 500;
+    font-size: 10px;
+    letter-spacing: -0.01em;
+    color: color-mix(in srgb, var(--t0), transparent 45%);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -75,7 +90,7 @@
   .crumb-meta {
     color: var(--t3);
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: 8.5px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -83,43 +98,50 @@
 
   .pills {
     display: flex;
-    gap: 8px;
+    gap: 6px;
     align-items: center;
     flex-shrink: 0;
   }
   .pill {
-    border: 1px solid var(--bd);
-    color: var(--t2);
+    border: 1px solid color-mix(in srgb, var(--ac), transparent 72%);
+    color: color-mix(in srgb, var(--ac), transparent 35%);
     border-radius: 999px;
-    padding: 5px 9px;
+    padding: 0 5px;
     font-family: var(--mono);
-    font-size: 10px;
-    background: rgba(255, 255, 255, 0.025);
+    font-size: 8.5px;
+    background: color-mix(in srgb, var(--ac), transparent 92%);
     white-space: nowrap;
+    line-height: 1.6;
   }
   .pill-status {
     color: var(--ac);
     background: color-mix(in srgb, var(--ac), transparent 90%);
     border-color: color-mix(in srgb, var(--ac), transparent 72%);
   }
+  .pill-model,
+  .pill-ctx {
+    border-color: var(--glass-border);
+    color: var(--t2);
+    background: var(--glass-bg);
+  }
 
   .close-btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 22px;
-    height: 22px;
-    border: 1px solid var(--bd);
-    border-radius: 8px;
+    width: 20px;
+    height: 20px;
+    border: 1px solid var(--glass-border);
+    border-radius: 6px;
     background: transparent;
     color: var(--t3);
-    font-size: 12px;
+    font-size: 11px;
     cursor: pointer;
     transition: all 0.12s;
   }
   .close-btn:hover {
     border-color: var(--t2);
     color: var(--t0);
-    background: var(--bg2);
+    background: var(--glass-bg);
   }
 </style>

--- a/ui/components/workspace/TabBar.svelte
+++ b/ui/components/workspace/TabBar.svelte
@@ -131,23 +131,26 @@
   .tab-bar {
     display: flex;
     align-items: center;
-    height: 35px;
-    padding: 0;
-    gap: 0;
-    border-bottom: 1px solid var(--bd);
-    background: var(--bg1);
+    height: 36px;
+    padding: 0 8px;
+    gap: 2px;
+    border-bottom: 1px solid var(--glass-border);
+    background: var(--glass-bg);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
     flex-shrink: 0;
     overflow: hidden;
   }
 
   .tab-list {
     display: flex;
-    align-items: stretch;
+    align-items: center;
     flex: 1;
     overflow-x: auto;
     scrollbar-width: none;
-    gap: 0;
+    gap: 2px;
     height: 100%;
+    padding: 4px 0;
   }
 
   .tab-list::-webkit-scrollbar {
@@ -191,19 +194,20 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 22px;
-    height: 22px;
+    width: 24px;
+    height: 24px;
     border: none;
     background: transparent;
     color: var(--t3);
     cursor: pointer;
     flex-shrink: 0;
-    border-radius: 0;
+    border-radius: 6px;
     transition: all 0.12s;
-    margin: 0 4px;
+    margin-left: auto;
   }
 
   .add-button:hover {
     color: var(--t1);
+    background: var(--glass-bg-subtle);
   }
 </style>

--- a/ui/components/workspace/TabItem.svelte
+++ b/ui/components/workspace/TabItem.svelte
@@ -48,16 +48,16 @@
 >
   <span class="tab-icon" aria-hidden="true">
     {#if tab.target.kind === 'agent'}
-      <Bot size={13} />
+      <Bot size={12} />
     {:else if tab.target.kind === 'git'}
-      <GitBranch size={13} />
+      <GitBranch size={12} />
     {:else}
-      <Terminal size={13} />
+      <Terminal size={12} />
     {/if}
   </span>
   <span class="tab-label">{label}</span>
   <button class="tab-close" on:click={handleClose} aria-label="Close tab">
-    <X size={12} />
+    <X size={11} />
   </button>
 </div>
 
@@ -66,49 +66,38 @@
     display: flex;
     align-items: center;
     gap: 5px;
-    padding: 0 12px;
-    height: 100%;
+    padding: 0 8px 0 6px;
+    height: 26px;
     min-width: 60px;
     max-width: 160px;
     cursor: pointer;
     user-select: none;
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: 9.5px;
     font-weight: 450;
-    color: var(--t2);
+    color: color-mix(in srgb, var(--t0), transparent 70%);
     border: none;
-    border-right: 1px solid var(--bd);
+    border-radius: 6px;
     background: transparent;
     flex-shrink: 0;
     white-space: nowrap;
     overflow: hidden;
     position: relative;
     transition:
-      background 0.1s,
-      color 0.1s;
+      background 0.12s,
+      color 0.12s,
+      box-shadow 0.12s;
   }
 
-  .tab-item:hover {
-    background: color-mix(in srgb, var(--bg), white 4%);
-    color: var(--t1);
+  .tab-item:hover:not(.active) {
+    color: color-mix(in srgb, var(--t0), transparent 50%);
   }
 
   .tab-item.active {
-    background: var(--bg);
+    background: var(--glass-tab-active-bg);
     color: var(--t0);
     font-weight: 500;
-    border-bottom: none;
-  }
-
-  .tab-item.active::after {
-    content: '';
-    position: absolute;
-    bottom: -1px;
-    left: 0;
-    right: 0;
-    height: 2px;
-    background: var(--ac);
-    z-index: 1;
+    box-shadow: var(--glass-tab-active-shadow);
   }
 
   /* Unfocused pane — subdued tabs */
@@ -117,23 +106,17 @@
   }
 
   .tab-item:not(.focused).active {
-    background: var(--bg);
-    color: var(--t1);
-    opacity: 0.7;
-  }
-
-  .tab-item:not(.focused).active::after {
-    opacity: 0.4;
+    opacity: 0.85;
   }
 
   .tab-icon {
     display: inline-flex;
     color: inherit;
     flex-shrink: 0;
+    opacity: 0.85;
   }
 
   .tab-label {
-    font-size: 10.5px;
     overflow: hidden;
     text-overflow: ellipsis;
     flex: 1;
@@ -143,14 +126,14 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 16px;
-    height: 16px;
+    width: 14px;
+    height: 14px;
     border: none;
     background: transparent;
-    color: var(--t2);
+    color: inherit;
     cursor: pointer;
     flex-shrink: 0;
-    border-radius: 3px;
+    border-radius: 4px;
     padding: 0;
     line-height: 1;
     transition:
@@ -161,16 +144,16 @@
   }
 
   .tab-item.active .tab-close {
-    opacity: 0.5;
+    opacity: 0.45;
   }
 
   .tab-item:hover .tab-close {
-    opacity: 0.7;
+    opacity: 0.65;
   }
 
   .tab-close:hover {
     color: var(--t0);
-    background: var(--bg3);
+    background: var(--glass-bg-subtle);
     opacity: 1;
   }
 </style>

--- a/ui/themes.css
+++ b/ui/themes.css
@@ -32,6 +32,15 @@
   --tool-bg: rgba(242, 201, 111, 0.07);
   --result-fg: #7a736b;
   --result-bg: rgba(255, 255, 255, 0.025);
+  --glass-bg: rgba(255, 255, 255, 0.015);
+  --glass-bg-subtle: rgba(255, 255, 255, 0.01);
+  --glass-bg-tree: rgba(255, 255, 255, 0.008);
+  --glass-border: rgba(255, 255, 255, 0.035);
+  --glass-border-subtle: rgba(255, 255, 255, 0.03);
+  --glass-blur: 12px;
+  --glass-tab-active-bg: rgba(124, 255, 158, 0.08);
+  --glass-tab-active-shadow:
+    0 0 0 1px rgba(124, 255, 158, 0.12), inset 0 0 20px rgba(124, 255, 158, 0.02);
 }
 
 /* ===== Light — Paper & Ink ===== */
@@ -69,6 +78,15 @@
   --tool-bg: rgba(146, 64, 14, 0.05);
   --result-fg: #9c9289;
   --result-bg: rgba(28, 25, 23, 0.02);
+  --glass-bg: rgba(28, 25, 23, 0.04);
+  --glass-bg-subtle: rgba(28, 25, 23, 0.025);
+  --glass-bg-tree: rgba(28, 25, 23, 0.03);
+  --glass-border: rgba(28, 25, 23, 0.1);
+  --glass-border-subtle: rgba(28, 25, 23, 0.07);
+  --glass-blur: 12px;
+  --glass-tab-active-bg: rgba(13, 122, 85, 0.1);
+  --glass-tab-active-shadow:
+    0 0 0 1px rgba(13, 122, 85, 0.18), inset 0 0 16px rgba(13, 122, 85, 0.04);
 }
 
 /* ===== Nord ===== */
@@ -104,6 +122,15 @@
   --tool-bg: rgba(235, 203, 139, 0.06);
   --result-fg: #81a1c1;
   --result-bg: rgba(216, 222, 233, 0.03);
+  --glass-bg: rgba(236, 239, 244, 0.04);
+  --glass-bg-subtle: rgba(236, 239, 244, 0.025);
+  --glass-bg-tree: rgba(236, 239, 244, 0.03);
+  --glass-border: rgba(236, 239, 244, 0.08);
+  --glass-border-subtle: rgba(236, 239, 244, 0.05);
+  --glass-blur: 12px;
+  --glass-tab-active-bg: rgba(163, 190, 140, 0.12);
+  --glass-tab-active-shadow:
+    0 0 0 1px rgba(163, 190, 140, 0.2), inset 0 0 16px rgba(163, 190, 140, 0.04);
 }
 
 /* ===== Dracula ===== */
@@ -139,6 +166,15 @@
   --tool-bg: rgba(255, 184, 108, 0.06);
   --result-fg: #6272a4;
   --result-bg: rgba(248, 248, 242, 0.02);
+  --glass-bg: rgba(248, 248, 242, 0.03);
+  --glass-bg-subtle: rgba(248, 248, 242, 0.02);
+  --glass-bg-tree: rgba(248, 248, 242, 0.025);
+  --glass-border: rgba(248, 248, 242, 0.06);
+  --glass-border-subtle: rgba(248, 248, 242, 0.04);
+  --glass-blur: 12px;
+  --glass-tab-active-bg: rgba(80, 250, 123, 0.1);
+  --glass-tab-active-shadow:
+    0 0 0 1px rgba(80, 250, 123, 0.18), inset 0 0 16px rgba(80, 250, 123, 0.03);
 }
 
 /* ===== Catppuccin Mocha ===== */
@@ -174,6 +210,15 @@
   --tool-bg: rgba(250, 179, 135, 0.06);
   --result-fg: #6c7086;
   --result-bg: rgba(205, 214, 244, 0.02);
+  --glass-bg: rgba(205, 214, 244, 0.04);
+  --glass-bg-subtle: rgba(205, 214, 244, 0.025);
+  --glass-bg-tree: rgba(205, 214, 244, 0.03);
+  --glass-border: rgba(205, 214, 244, 0.07);
+  --glass-border-subtle: rgba(205, 214, 244, 0.05);
+  --glass-blur: 12px;
+  --glass-tab-active-bg: rgba(166, 227, 161, 0.1);
+  --glass-tab-active-shadow:
+    0 0 0 1px rgba(166, 227, 161, 0.18), inset 0 0 16px rgba(166, 227, 161, 0.03);
 }
 
 /* ===== Steel Workshop ===== */
@@ -210,4 +255,13 @@
   --tool-bg: rgba(232, 184, 76, 0.05);
   --result-fg: #6b7084;
   --result-bg: rgba(255, 255, 255, 0.02);
+  --glass-bg: rgba(236, 237, 238, 0.04);
+  --glass-bg-subtle: rgba(236, 237, 238, 0.025);
+  --glass-bg-tree: rgba(236, 237, 238, 0.03);
+  --glass-border: rgba(236, 237, 238, 0.07);
+  --glass-border-subtle: rgba(236, 237, 238, 0.05);
+  --glass-blur: 12px;
+  --glass-tab-active-bg: rgba(79, 140, 255, 0.1);
+  --glass-tab-active-shadow:
+    0 0 0 1px rgba(79, 140, 255, 0.2), inset 0 0 16px rgba(79, 140, 255, 0.03);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves **ORB-12** by bringing the legacy **Glass Tier** visual language from `orbit-tabs-v3.html` into the current Quiet Journal workspace without reverting the newer feed/sidebar/composer layout.

## What changed

- **Theme tokens** (`ui/themes.css`): per-theme `--glass-*` variables (surface, border, blur, active-tab glow) so glass chrome works across Dark, Light, Nord, Dracula, Catppuccin, and Steel.
- **Tab bar** (`TabBar.svelte`, `TabItem.svelte`): frosted bar with `backdrop-filter: blur(12px)`, rounded pill tabs, accent glow on the active tab (replacing flat bordered tabs).
- **Panel headers** (`PanelHeader.svelte`): compact 36px glass header with status dot, smaller pills, and translucent background.
- **Git panel** (`GitPanel.svelte`, `GitTreeNode.svelte`): glass tree sidebar and diff header aligned with the mock.

## Verification

- `npm run check` — pass
- `npm test` — pass (unit + component)
- `npx prettier --check` + `npx eslint ui --max-warnings 0` — pass

## User-visible effect

Tabs and panel chrome feel lighter and layered (frosted glass) like the earlier Orbit direction, while Quiet Journal timeline/feed/composer behavior stays unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ORB-12](https://linear.app/aiorbit/issue/ORB-12/this-pr-is-about-the-old-visual-version-of-orbit-use-the-same-context)

<div><a href="https://cursor.com/agents/bc-bf1acf23-5105-4996-ab87-301fe1a59d70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf1acf23-5105-4996-ab87-301fe1a59d70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

