### PR TITLE
feat: optional frosted chrome and Glass theme (ORB-12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## May 2026
 
+### 05/25 · New — Optional frosted workspace chrome (Glass Tier)
+You can turn on translucent, blurred tab bars, panel headers, and git sidebars without changing your color theme. Open the palette menu in the sidebar and enable **Frosted chrome**, or pick the **Glass** theme preset (dark palette + frosted chrome). The Quiet Journal feed, sidebar, and composer stay the same.
+
 ### 05/21 · Adjustment — Tighter border-radius, tool card copy buttons, full-width cards
 Cards, inputs, modals, and sidebar items now use smaller border-radius (4px/8px/12px) for a sharper look. Tool cards are full-width with copy buttons for both command and output, each labeled "cmd" and "out". The scroll-to-bottom button sits on the left aligned with the chat timeline. The "working" pill has a subtle pulse animation.
 The dark theme now uses a warmer palette: backgrounds shifted from pure black (#080808) to near-black with subtle warmth (#090a0a), text is now a softer off-white (#f1ece3), borders use translucent warm white (rgba 241,236,227), and the green accent is a calmer tone (#7bd99d). Reading long sessions is now noticeably more comfortable.

--- a/docs/specs/glass-chrome.md
+++ b/docs/specs/glass-chrome.md
@@ -1,0 +1,24 @@
+# Glass chrome (ORB-12)
+
+## Objective
+
+Port the legacy **Glass Tier** look from `orbit-tabs-v3.html` into the current Quiet Journal UI without forcing it on every theme.
+
+## Behavior
+
+- **Frosted chrome** toggle (palette menu): when enabled, sets `data-glass-chrome="true"` on `<html>` and applies translucent surfaces + `backdrop-filter: blur(12px)` to workspace chrome only (tab bar, panel headers, git tree/diff header).
+- **Glass theme**: color preset (dark-tuned) that also enables frosted chrome when selected.
+- **Quiet Journal** areas (feed, sidebar, composer) are unchanged in both modes.
+- Per-theme `--glass-*` CSS variables supply accent-aware frosted colors for every palette.
+
+## Edge cases
+
+- Toggling frosted chrome off while on Glass theme keeps Glass colors but solid chrome.
+- Preference persists in `localStorage` (`glassChrome`).
+- Invalid stored theme falls back to `dark`; invalid `glassChrome` defaults to off unless theme is `glass`.
+
+## Acceptance
+
+- Default install: no frosted chrome, existing Quiet chrome unchanged.
+- Frosted chrome on + any theme: glass styling on tab/header/git shell only.
+- Glass theme selects dark glass palette and enables frosted chrome.

--- a/ui/components/GitPanel.svelte
+++ b/ui/components/GitPanel.svelte
@@ -686,4 +686,33 @@
     color: var(--ac);
     background: var(--ac-d2);
   }
+
+  :global(html[data-glass-chrome='true']) .diff-header {
+    border-bottom-color: var(--glass-border-subtle);
+    background: var(--glass-bg-subtle);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
+    font-size: 9px;
+    color: color-mix(in srgb, var(--t0), transparent 55%);
+  }
+
+  :global(html[data-glass-chrome='true']) .tree-pane {
+    border-right-color: var(--glass-border);
+    background: var(--glass-bg-tree);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
+  }
+
+  :global(html[data-glass-chrome='true']) .tree-tools {
+    border-bottom-color: var(--glass-border-subtle);
+  }
+
+  :global(html[data-glass-chrome='true']) .tree-tools input {
+    border-color: var(--glass-border);
+    background: var(--glass-bg);
+  }
+
+  :global(html[data-glass-chrome='true']) .selection-bar {
+    border-bottom-color: var(--glass-border-subtle);
+  }
 </style>

--- a/ui/components/GitTreeNode.svelte
+++ b/ui/components/GitTreeNode.svelte
@@ -131,6 +131,19 @@
     background: rgba(0, 212, 126, 0.06);
   }
 
+  :global(html[data-glass-chrome='true']) .tree-row:hover {
+    background: var(--glass-bg-subtle);
+  }
+
+  :global(html[data-glass-chrome='true']) .folder-row {
+    color: color-mix(in srgb, var(--t0), transparent 35%);
+  }
+
+  :global(html[data-glass-chrome='true']) .file-row.selected {
+    background: var(--glass-tab-active-bg);
+    color: color-mix(in srgb, var(--t0), transparent 50%);
+  }
+
   .expand-btn,
   .check-btn {
     display: inline-flex;

--- a/ui/components/ThemePicker.svelte
+++ b/ui/components/ThemePicker.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import { theme, THEME_OPTIONS, THEME_LABELS, type Theme } from '../lib/stores/preferences';
+  import {
+    theme,
+    glassChrome,
+    THEME_OPTIONS,
+    THEME_LABELS,
+    type Theme,
+  } from '../lib/stores/preferences';
   import { Palette } from 'lucide-svelte';
 
   let open = false;
@@ -7,6 +13,10 @@
   function select(t: Theme) {
     theme.set(t);
     open = false;
+  }
+
+  function toggleGlassChrome() {
+    glassChrome.set(!$glassChrome);
   }
 
   function toggle(e: MouseEvent) {
@@ -41,6 +51,16 @@
           {THEME_LABELS[t]}
         </button>
       {/each}
+      <div class="divider" role="separator"></div>
+      <button
+        class="option glass-toggle"
+        class:active={$glassChrome}
+        onclick={toggleGlassChrome}
+        title="Frosted translucent tab bar, panel headers, and git sidebar"
+      >
+        <span class="swatch glass-swatch" class:on={$glassChrome}></span>
+        Frosted chrome
+      </button>
     </div>
   {/if}
 </div>
@@ -81,9 +101,15 @@
     display: flex;
     flex-direction: column;
     gap: var(--sp-1);
-    min-width: 130px;
+    min-width: 150px;
     z-index: 100;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  }
+
+  .divider {
+    height: 1px;
+    margin: var(--sp-1) 0;
+    background: var(--bd);
   }
 
   .option {
@@ -117,6 +143,17 @@
     flex-shrink: 0;
   }
 
+  .glass-swatch {
+    border-radius: 3px;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+    backdrop-filter: blur(4px);
+  }
+
+  .glass-swatch.on {
+    border-color: var(--ac-border);
+    box-shadow: 0 0 0 1px var(--ac-d);
+  }
+
   .swatch[data-theme-preview='dark'] {
     background: #080808;
   }
@@ -135,5 +172,9 @@
   .swatch[data-theme-preview='steel'] {
     background: #0b0d10;
     border-color: #303447;
+  }
+  .swatch[data-theme-preview='glass'] {
+    background: linear-gradient(135deg, #0c0d0d 40%, rgba(124, 255, 158, 0.15));
+    border-color: rgba(124, 255, 158, 0.35);
   }
 </style>

--- a/ui/components/workspace/PanelHeader.component.test.ts
+++ b/ui/components/workspace/PanelHeader.component.test.ts
@@ -14,7 +14,8 @@ describe('PanelHeader', () => {
       },
     });
 
-    expect(container.querySelector('header.quiet-topbar')).toBeTruthy();
+    expect(container.querySelector('header.topbar.quiet-topbar')).toBeTruthy();
+    expect(container.querySelector('header.glass-topbar')).toBeFalsy();
     expect(getByText('Refactor billing flow')).toBeTruthy();
     expect(getByText('running')).toBeTruthy();
     await fireEvent.click(getByLabelText('Close panel'));

--- a/ui/components/workspace/PanelHeader.svelte
+++ b/ui/components/workspace/PanelHeader.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { glassChrome } from '../../lib/stores/preferences';
+
   export let title: string;
   export let meta: string | null = null;
   export let status: string | null = null;
@@ -9,8 +11,11 @@
   export let focused: boolean = true;
 </script>
 
-<header class="topbar quiet-topbar" class:focused>
+<header class="topbar quiet-topbar" class:glass-topbar={$glassChrome} class:focused>
   <div class="crumb">
+    {#if $glassChrome && statusColor}
+      <span class="status-dot" style="background: {statusColor}" aria-hidden="true"></span>
+    {/if}
     <span class="crumb-title" {title}>{title}</span>
     {#if meta}
       <span class="crumb-meta" title={meta}>{meta}</span>
@@ -50,6 +55,16 @@
     user-select: none;
     min-width: 0;
   }
+
+  .topbar.glass-topbar {
+    height: 36px;
+    padding: 0 10px;
+    border-bottom-color: var(--glass-border-subtle);
+    background: var(--glass-bg-subtle);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
+  }
+
   .topbar:not(.focused) {
     opacity: 0.65;
   }
@@ -64,6 +79,19 @@
     min-width: 0;
     overflow: hidden;
   }
+
+  .glass-topbar .crumb {
+    gap: 8px;
+  }
+
+  .status-dot {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    box-shadow: 0 0 8px color-mix(in srgb, currentColor, transparent 40%);
+  }
+
   .crumb-title {
     font-weight: 700;
     letter-spacing: -0.02em;
@@ -72,6 +100,14 @@
     overflow: hidden;
     text-overflow: ellipsis;
   }
+
+  .glass-topbar .crumb-title {
+    font-weight: 500;
+    font-size: 10px;
+    letter-spacing: -0.01em;
+    color: color-mix(in srgb, var(--t0), transparent 45%);
+  }
+
   .crumb-meta {
     color: var(--t3);
     font-family: var(--mono);
@@ -81,12 +117,21 @@
     text-overflow: ellipsis;
   }
 
+  .glass-topbar .crumb-meta {
+    font-size: 8.5px;
+  }
+
   .pills {
     display: flex;
     gap: 8px;
     align-items: center;
     flex-shrink: 0;
   }
+
+  .glass-topbar .pills {
+    gap: 6px;
+  }
+
   .pill {
     border: 1px solid var(--bd);
     color: var(--t2);
@@ -97,10 +142,27 @@
     background: rgba(255, 255, 255, 0.025);
     white-space: nowrap;
   }
+
+  .glass-topbar .pill {
+    border-color: color-mix(in srgb, var(--ac), transparent 72%);
+    color: color-mix(in srgb, var(--ac), transparent 35%);
+    padding: 0 5px;
+    font-size: 8.5px;
+    background: color-mix(in srgb, var(--ac), transparent 92%);
+    line-height: 1.6;
+  }
+
   .pill-status {
     color: var(--ac);
     background: color-mix(in srgb, var(--ac), transparent 90%);
     border-color: color-mix(in srgb, var(--ac), transparent 72%);
+  }
+
+  .glass-topbar .pill-model,
+  .glass-topbar .pill-ctx {
+    border-color: var(--glass-border);
+    color: var(--t2);
+    background: var(--glass-bg);
   }
 
   .close-btn {
@@ -117,9 +179,22 @@
     cursor: pointer;
     transition: all 0.12s;
   }
+
+  .glass-topbar .close-btn {
+    width: 20px;
+    height: 20px;
+    border-color: var(--glass-border);
+    border-radius: 6px;
+    font-size: 11px;
+  }
+
   .close-btn:hover {
     border-color: var(--t2);
     color: var(--t0);
     background: var(--bg2);
+  }
+
+  .glass-topbar .close-btn:hover {
+    background: var(--glass-bg);
   }
 </style>

--- a/ui/components/workspace/TabBar.svelte
+++ b/ui/components/workspace/TabBar.svelte
@@ -140,6 +140,16 @@
     overflow: hidden;
   }
 
+  :global(html[data-glass-chrome='true']) .tab-bar {
+    height: 36px;
+    padding: 0 8px;
+    gap: 2px;
+    border-bottom-color: var(--glass-border);
+    background: var(--glass-bg);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
+  }
+
   .tab-list {
     display: flex;
     align-items: stretch;
@@ -148,6 +158,12 @@
     scrollbar-width: none;
     gap: 0;
     height: 100%;
+  }
+
+  :global(html[data-glass-chrome='true']) .tab-list {
+    align-items: center;
+    gap: 2px;
+    padding: 4px 0;
   }
 
   .tab-list::-webkit-scrollbar {
@@ -203,7 +219,19 @@
     margin: 0 4px;
   }
 
+  :global(html[data-glass-chrome='true']) .add-button {
+    width: 24px;
+    height: 24px;
+    border-radius: 6px;
+    margin-left: auto;
+    margin-right: 0;
+  }
+
   .add-button:hover {
     color: var(--t1);
+  }
+
+  :global(html[data-glass-chrome='true']) .add-button:hover {
+    background: var(--glass-bg-subtle);
   }
 </style>

--- a/ui/components/workspace/TabItem.svelte
+++ b/ui/components/workspace/TabItem.svelte
@@ -88,9 +88,27 @@
       color 0.1s;
   }
 
+  :global(html[data-glass-chrome='true']) .tab-item {
+    padding: 0 8px 0 6px;
+    height: 26px;
+    font-size: 9.5px;
+    color: color-mix(in srgb, var(--t0), transparent 70%);
+    border-right: none;
+    border-radius: 6px;
+    transition:
+      background 0.12s,
+      color 0.12s,
+      box-shadow 0.12s;
+  }
+
   .tab-item:hover {
     background: color-mix(in srgb, var(--bg), white 4%);
     color: var(--t1);
+  }
+
+  :global(html[data-glass-chrome='true']) .tab-item:hover:not(.active) {
+    background: transparent;
+    color: color-mix(in srgb, var(--t0), transparent 50%);
   }
 
   .tab-item.active {
@@ -111,6 +129,15 @@
     z-index: 1;
   }
 
+  :global(html[data-glass-chrome='true']) .tab-item.active {
+    background: var(--glass-tab-active-bg);
+    box-shadow: var(--glass-tab-active-shadow);
+  }
+
+  :global(html[data-glass-chrome='true']) .tab-item.active::after {
+    content: none;
+  }
+
   /* Unfocused pane — subdued tabs */
   .tab-item:not(.focused) {
     opacity: 0.7;
@@ -126,10 +153,24 @@
     opacity: 0.4;
   }
 
+  :global(html[data-glass-chrome='true']) .tab-item:not(.focused).active {
+    background: var(--glass-tab-active-bg);
+    color: var(--t0);
+    opacity: 0.85;
+  }
+
+  :global(html[data-glass-chrome='true']) .tab-item:not(.focused).active::after {
+    content: none;
+  }
+
   .tab-icon {
     display: inline-flex;
     color: inherit;
     flex-shrink: 0;
+  }
+
+  :global(html[data-glass-chrome='true']) .tab-icon {
+    opacity: 0.85;
   }
 
   .tab-label {
@@ -137,6 +178,10 @@
     overflow: hidden;
     text-overflow: ellipsis;
     flex: 1;
+  }
+
+  :global(html[data-glass-chrome='true']) .tab-label {
+    font-size: inherit;
   }
 
   .tab-close {
@@ -160,6 +205,13 @@
     opacity: 0;
   }
 
+  :global(html[data-glass-chrome='true']) .tab-close {
+    width: 14px;
+    height: 14px;
+    color: inherit;
+    border-radius: 4px;
+  }
+
   .tab-item.active .tab-close {
     opacity: 0.5;
   }
@@ -168,9 +220,21 @@
     opacity: 0.7;
   }
 
+  :global(html[data-glass-chrome='true']) .tab-item.active .tab-close {
+    opacity: 0.45;
+  }
+
+  :global(html[data-glass-chrome='true']) .tab-item:hover .tab-close {
+    opacity: 0.65;
+  }
+
   .tab-close:hover {
     color: var(--t0);
     background: var(--bg3);
     opacity: 1;
+  }
+
+  :global(html[data-glass-chrome='true']) .tab-close:hover {
+    background: var(--glass-bg-subtle);
   }
 </style>

--- a/ui/lib/stores/preferences.test.ts
+++ b/ui/lib/stores/preferences.test.ts
@@ -6,6 +6,7 @@ describe('preferences stores', () => {
     vi.resetModules();
     localStorage.clear();
     document.documentElement.removeAttribute('data-theme');
+    document.documentElement.removeAttribute('data-glass-chrome');
   });
 
   it('defaults inspector/meta panel to hidden for Quiet Journal', async () => {
@@ -21,5 +22,23 @@ describe('preferences stores', () => {
     compactDensity.set(true);
     expect(get(compactDensity)).toBe(true);
     expect(localStorage.getItem('compactDensity')).toBe('true');
+  });
+
+  it('defaults frosted chrome off and persists when toggled', async () => {
+    const { glassChrome } = await import('./preferences');
+    expect(get(glassChrome)).toBe(false);
+    expect(document.documentElement.hasAttribute('data-glass-chrome')).toBe(false);
+    glassChrome.set(true);
+    expect(get(glassChrome)).toBe(true);
+    expect(document.documentElement.getAttribute('data-glass-chrome')).toBe('true');
+    expect(localStorage.getItem('glassChrome')).toBe('true');
+  });
+
+  it('enables frosted chrome when Glass theme is selected', async () => {
+    const { theme, glassChrome } = await import('./preferences');
+    theme.set('glass');
+    expect(get(theme)).toBe('glass');
+    expect(get(glassChrome)).toBe(true);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('glass');
   });
 });

--- a/ui/lib/stores/preferences.ts
+++ b/ui/lib/stores/preferences.ts
@@ -1,6 +1,14 @@
 import { writable } from 'svelte/store';
 
-export const THEME_OPTIONS = ['dark', 'light', 'nord', 'dracula', 'catppuccin', 'steel'] as const;
+export const THEME_OPTIONS = [
+  'dark',
+  'light',
+  'nord',
+  'dracula',
+  'catppuccin',
+  'steel',
+  'glass',
+] as const;
 export type Theme = (typeof THEME_OPTIONS)[number];
 
 export const THEME_LABELS: Record<Theme, string> = {
@@ -10,7 +18,10 @@ export const THEME_LABELS: Record<Theme, string> = {
   dracula: 'Dracula',
   catppuccin: 'Catppuccin',
   steel: 'Steel Workshop',
+  glass: 'Glass',
 };
+
+const GLASS_CHROME_KEY = 'glassChrome';
 
 function applyTheme(value: Theme) {
   if (typeof document !== 'undefined') {
@@ -19,9 +30,52 @@ function applyTheme(value: Theme) {
   }
 }
 
+function applyGlassChrome(enabled: boolean) {
+  if (typeof document !== 'undefined') {
+    if (enabled) {
+      document.documentElement.setAttribute('data-glass-chrome', 'true');
+    } else {
+      document.documentElement.removeAttribute('data-glass-chrome');
+    }
+    localStorage.setItem(GLASS_CHROME_KEY, String(enabled));
+  }
+}
+
 function isValidTheme(value: string | null): value is Theme {
   return value !== null && (THEME_OPTIONS as readonly string[]).includes(value);
 }
+
+function readGlassChromeInitial(): boolean {
+  const stored =
+    typeof localStorage !== 'undefined' ? localStorage.getItem(GLASS_CHROME_KEY) : null;
+  if (stored !== null) return stored === 'true';
+  const themeStored = typeof localStorage !== 'undefined' ? localStorage.getItem('theme') : null;
+  return themeStored === 'glass';
+}
+
+function createGlassChromeStore() {
+  const initial = readGlassChromeInitial();
+  const { subscribe, set: _set, update } = writable<boolean>(initial);
+
+  applyGlassChrome(initial);
+
+  return {
+    subscribe,
+    set(value: boolean) {
+      _set(value);
+      applyGlassChrome(value);
+    },
+    toggle() {
+      update((current) => {
+        const next = !current;
+        applyGlassChrome(next);
+        return next;
+      });
+    },
+  };
+}
+
+export const glassChrome = createGlassChromeStore();
 
 function createThemeStore() {
   const stored = typeof localStorage !== 'undefined' ? localStorage.getItem('theme') : null;
@@ -35,12 +89,18 @@ function createThemeStore() {
     set(value: Theme) {
       _set(value);
       applyTheme(value);
+      if (value === 'glass') {
+        glassChrome.set(true);
+      }
     },
     cycle() {
       update((current) => {
         const idx = THEME_OPTIONS.indexOf(current);
         const next = THEME_OPTIONS[(idx + 1) % THEME_OPTIONS.length];
         applyTheme(next);
+        if (next === 'glass') {
+          glassChrome.set(true);
+        }
         return next;
       });
     },

--- a/ui/themes.css
+++ b/ui/themes.css
@@ -32,6 +32,15 @@
   --tool-bg: rgba(242, 201, 111, 0.07);
   --result-fg: #7a736b;
   --result-bg: rgba(255, 255, 255, 0.025);
+  --glass-bg: rgba(255, 255, 255, 0.015);
+  --glass-bg-subtle: rgba(255, 255, 255, 0.01);
+  --glass-bg-tree: rgba(255, 255, 255, 0.008);
+  --glass-border: rgba(255, 255, 255, 0.035);
+  --glass-border-subtle: rgba(255, 255, 255, 0.03);
+  --glass-blur: 12px;
+  --glass-tab-active-bg: rgba(124, 255, 158, 0.08);
+  --glass-tab-active-shadow:
+    0 0 0 1px rgba(124, 255, 158, 0.12), inset 0 0 20px rgba(124, 255, 158, 0.02);
 }
 
 /* ===== Light — Paper & Ink ===== */
@@ -69,6 +78,15 @@
   --tool-bg: rgba(146, 64, 14, 0.05);
   --result-fg: #9c9289;
   --result-bg: rgba(28, 25, 23, 0.02);
+  --glass-bg: rgba(28, 25, 23, 0.04);
+  --glass-bg-subtle: rgba(28, 25, 23, 0.025);
+  --glass-bg-tree: rgba(28, 25, 23, 0.03);
+  --glass-border: rgba(28, 25, 23, 0.1);
+  --glass-border-subtle: rgba(28, 25, 23, 0.07);
+  --glass-blur: 12px;
+  --glass-tab-active-bg: rgba(13, 122, 85, 0.1);
+  --glass-tab-active-shadow:
+    0 0 0 1px rgba(13, 122, 85, 0.18), inset 0 0 16px rgba(13, 122, 85, 0.04);
 }
 
 /* ===== Nord ===== */
@@ -104,6 +122,15 @@
   --tool-bg: rgba(235, 203, 139, 0.06);
   --result-fg: #81a1c1;
   --result-bg: rgba(216, 222, 233, 0.03);
+  --glass-bg: rgba(236, 239, 244, 0.04);
+  --glass-bg-subtle: rgba(236, 239, 244, 0.025);
+  --glass-bg-tree: rgba(236, 239, 244, 0.03);
+  --glass-border: rgba(236, 239, 244, 0.08);
+  --glass-border-subtle: rgba(236, 239, 244, 0.05);
+  --glass-blur: 12px;
+  --glass-tab-active-bg: rgba(163, 190, 140, 0.12);
+  --glass-tab-active-shadow:
+    0 0 0 1px rgba(163, 190, 140, 0.2), inset 0 0 16px rgba(163, 190, 140, 0.04);
 }
 
 /* ===== Dracula ===== */
@@ -139,6 +166,15 @@
   --tool-bg: rgba(255, 184, 108, 0.06);
   --result-fg: #6272a4;
   --result-bg: rgba(248, 248, 242, 0.02);
+  --glass-bg: rgba(248, 248, 242, 0.03);
+  --glass-bg-subtle: rgba(248, 248, 242, 0.02);
+  --glass-bg-tree: rgba(248, 248, 242, 0.025);
+  --glass-border: rgba(248, 248, 242, 0.06);
+  --glass-border-subtle: rgba(248, 248, 242, 0.04);
+  --glass-blur: 12px;
+  --glass-tab-active-bg: rgba(80, 250, 123, 0.1);
+  --glass-tab-active-shadow:
+    0 0 0 1px rgba(80, 250, 123, 0.18), inset 0 0 16px rgba(80, 250, 123, 0.03);
 }
 
 /* ===== Catppuccin Mocha ===== */
@@ -174,6 +210,15 @@
   --tool-bg: rgba(250, 179, 135, 0.06);
   --result-fg: #6c7086;
   --result-bg: rgba(205, 214, 244, 0.02);
+  --glass-bg: rgba(205, 214, 244, 0.04);
+  --glass-bg-subtle: rgba(205, 214, 244, 0.025);
+  --glass-bg-tree: rgba(205, 214, 244, 0.03);
+  --glass-border: rgba(205, 214, 244, 0.07);
+  --glass-border-subtle: rgba(205, 214, 244, 0.05);
+  --glass-blur: 12px;
+  --glass-tab-active-bg: rgba(166, 227, 161, 0.1);
+  --glass-tab-active-shadow:
+    0 0 0 1px rgba(166, 227, 161, 0.18), inset 0 0 16px rgba(166, 227, 161, 0.03);
 }
 
 /* ===== Steel Workshop ===== */
@@ -210,4 +255,57 @@
   --tool-bg: rgba(232, 184, 76, 0.05);
   --result-fg: #6b7084;
   --result-bg: rgba(255, 255, 255, 0.02);
+  --glass-bg: rgba(236, 237, 238, 0.04);
+  --glass-bg-subtle: rgba(236, 237, 238, 0.025);
+  --glass-bg-tree: rgba(236, 237, 238, 0.03);
+  --glass-border: rgba(236, 237, 238, 0.07);
+  --glass-border-subtle: rgba(236, 237, 238, 0.05);
+  --glass-blur: 12px;
+  --glass-tab-active-bg: rgba(79, 140, 255, 0.1);
+  --glass-tab-active-shadow:
+    0 0 0 1px rgba(79, 140, 255, 0.2), inset 0 0 16px rgba(79, 140, 255, 0.03);
+}
+
+/* ===== Glass — dark palette tuned for frosted workspace chrome ===== */
+[data-theme='glass'] {
+  --bg: #090a0a;
+  --bg1: #0c0d0d;
+  --bg2: #101111;
+  --bg3: #141515;
+  --bg4: #191a1a;
+  --bg-sidebar: #0c0d0d;
+  --bd: rgba(241, 236, 227, 0.1);
+  --bd1: rgba(241, 236, 227, 0.14);
+  --bd2: rgba(241, 236, 227, 0.18);
+  --t0: #f1ece3;
+  --t1: #a19a90;
+  --t2: #7a736b;
+  --t3: #67615a;
+  --ac: #7cff9e;
+  --ac-d: rgba(124, 255, 158, 0.12);
+  --ac-d2: rgba(124, 255, 158, 0.06);
+  --ac-border: rgba(124, 255, 158, 0.32);
+  --s-working: #7cff9e;
+  --s-input: #f2c96f;
+  --s-idle: #67615a;
+  --s-error: #e47770;
+  --s-init: #4da3ff;
+  --s-done: #3b3d3d;
+  --user-fg: #4da3ff;
+  --user-bg: rgba(77, 163, 255, 0.1);
+  --think-fg: #c8a8ff;
+  --think-bg: rgba(200, 168, 255, 0.08);
+  --tool-fg: #f2c96f;
+  --tool-bg: rgba(242, 201, 111, 0.07);
+  --result-fg: #7a736b;
+  --result-bg: rgba(255, 255, 255, 0.025);
+  --glass-bg: rgba(255, 255, 255, 0.02);
+  --glass-bg-subtle: rgba(255, 255, 255, 0.012);
+  --glass-bg-tree: rgba(255, 255, 255, 0.01);
+  --glass-border: rgba(255, 255, 255, 0.04);
+  --glass-border-subtle: rgba(255, 255, 255, 0.032);
+  --glass-blur: 12px;
+  --glass-tab-active-bg: rgba(124, 255, 158, 0.1);
+  --glass-tab-active-shadow:
+    0 0 0 1px rgba(124, 255, 158, 0.16), inset 0 0 20px rgba(124, 255, 158, 0.03);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses feedback on ORB-12: the Glass Tier look from the legacy mock is **opt-in**, not forced on every theme.

- **Frosted chrome** toggle in the palette menu — enables translucent blurred workspace chrome (tab bar, panel headers, git tree/diff header) on **any** color theme
- **Glass** theme preset — dark palette tuned for glass + auto-enables frosted chrome when selected
- Quiet Journal feed, sidebar, and composer are unchanged

## How to try

1. Open the palette icon in the sidebar footer
2. Toggle **Frosted chrome**, or pick **Glass**
3. Confirm tabs/headers/git shell get the frosted look while chat/sidebar stay the same

## Technical notes

- `data-glass-chrome="true"` on `<html>` gates glass styles; `glassChrome` preference persists in localStorage
- Per-theme `--glass-*` CSS variables keep accent colors consistent across palettes

Closes ORB-12
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ORB-12](https://linear.app/aiorbit/issue/ORB-12/this-pr-is-about-the-old-visual-version-of-orbit-use-the-same-context)

<div><a href="https://cursor.com/agents/bc-75ce9993-5090-4744-b8e7-90af5236463a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75ce9993-5090-4744-b8e7-90af5236463a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

